### PR TITLE
Voeg ZeroDivisionError toe

### DIFF
--- a/chapters/03 expressions/06 exercises/03 ZeroDivisionError/config.json
+++ b/chapters/03 expressions/06 exercises/03 ZeroDivisionError/config.json
@@ -6,6 +6,9 @@
     }
   },
   "labels": [],
+  "evaluation": {
+    "handler": "universal"
+  },
   "internals": {
     "token": "DAKdY7NzSNczCXQSFVJQSBCUhp5aTJNVHysqygVZna-2xgX9jvigPyA63gI6Egss",
     "_info": "These fields are used for internal bookkeeping in Dodona, please do not change them."

--- a/chapters/03 expressions/06 exercises/03 ZeroDivisionError/evaluation/evaluator.py
+++ b/chapters/03 expressions/06 exercises/03 ZeroDivisionError/evaluation/evaluator.py
@@ -1,0 +1,17 @@
+import traceback
+import specific_evaluation_utils as u
+
+
+def evaluate(value):
+    if isinstance(value, ZeroDivisionError):
+        # If a zero division error, show the stacktrace.
+        formatted = "".join(traceback.format_exception(type(value), value, value.__traceback__))
+        u.evaluated(True, formatted, formatted)
+    elif isinstance(value, Exception):
+        # If another error, show the stacktrace as well.
+        formatted = "".join(traceback.format_exception(type(value), value, value.__traceback__))
+        u.evaluated(False, "ZeroDivisionError", formatted, [f"Verwachtte een ZeroDivisionError, maar kreeg een {type(value).__name__}"])
+    else:
+        # Else show the str of the value.
+        actual = str(value) if value else ""
+        u.evaluated(False, "ZeroDivisionError", actual, ["Verwachtte een ZeroDivisionError."])

--- a/chapters/03 expressions/06 exercises/03 ZeroDivisionError/evaluation/plan.json
+++ b/chapters/03 expressions/06 exercises/03 ZeroDivisionError/evaluation/plan.json
@@ -1,0 +1,27 @@
+{
+  "tabs": [
+    {
+      "name": "Correctheid",
+      "contexts": [
+        {
+          "context_testcase": {
+            "description": "Uitvoeren code",
+            "input": {
+              "main_call": true
+            },
+            "output": {
+              "exception": {
+                "evaluator": {
+                  "type": "specific",
+                  "evaluators": {
+                    "python": "evaluator.py"
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
De configuratie voor de oefening met TESTed. Ik heb ondertussen ook TESTed op Dodona zelf bijgewerkt, dus zou het moeten werken. (Ik heb het wel enkel lokaal getest).

Qua structuur is de oefening eenvoudig: er is één testgeval in één context met een taalspecifieke evaluator. De exception wordt opgevangen door TESTed, waarna de evaluator controleert of het een `ZeroDivisionError` is.