### PR TITLE
fix: Fix erronious text in ``

### DIFF
--- a/chapters/10 strings/06 string methods/description/description.en.md
+++ b/chapters/10 strings/06 string methods/description/description.en.md
@@ -138,8 +138,7 @@ In the string
 the word `"wood"` is misspelled. Use `replace()` to replace all
 occurrences of this spelling error with the correct spelling.
 
-Display the contents of the string `"Nobody expects the Spanish`
-`Inquisition!# In fact, those who do expect the Spanish Inquisition..."`
+Display the contents of the string `"Nobody expects the Spanish Inquisition!# In fact, those who do expect the Spanish Inquisition..."`
 up to, but not including, the hash mark (`#`). Use `find()` to get the
 index of the hash mark.
 

--- a/chapters/10 strings/06 string methods/description/description.nl.md
+++ b/chapters/10 strings/06 string methods/description/description.nl.md
@@ -151,8 +151,7 @@ In de string
 is het woord `"rabarber"` verkeerd gespeld. Gebruik `replace()` om alle
 voorkomende gevallen van deze fout te verbeteren.
 
-Neem de string `"Niemand verwacht de Spaanse Inquisitie\`\# In feite,!
-`zij die de Spaanse Inquisitie wel verwachten..."` en toon hem tot aan,
+Neem de string `"Niemand verwacht de Spaanse Inquisitie# In feite,! zij die de Spaanse Inquisitie wel verwachten..."` en toon hem tot aan,
 maar niet inclusief, de hash mark (`#`). Gebruik `find()` om de index van
 de hash mark te bepalen.
 


### PR DESCRIPTION
Likely fixes the incorrect formatting of "Niemand verwacht de Spaanse..." on https://dodona.ugent.be/nl/courses/293/series/2542/activities/384522259/