### PR TITLE
Fix underspecified/incorrect exercise descriptions and a test fragility bug

### DIFF
--- a/chapters/08 functions/08 exercises/05 loop-and-a-half/description/description.en.md
+++ b/chapters/08 functions/08 exercises/05 loop-and-a-half/description/description.en.md
@@ -31,3 +31,34 @@ while True:
 
 print( "Goodbye!" )
 ```
+
+### Assignment
+
+Write a function `get_valid_number` that takes a prompt (`str`). The function
+must use `getInteger` to keep asking for an integer using the given prompt,
+until the user enters a value between 0 and 1000 (inclusive); for every value
+outside that range, print `The numbers should be between 0 and 1000` before
+asking again. The function must return the validated integer (`int`).
+
+Rewrite the code above into a function `main` that takes no arguments, using
+`get_valid_number` to fix the issue described above. Also get rid of the
+`exit()` by using `return` instead.
+
+### Example
+
+```console?lang=python&prompt=>>>
+>>> get_valid_number("Enter number 1: ")
+Enter number 1: -42
+The numbers should be between 0 and 1000
+Enter number 1: 314
+314
+
+>>> main()
+Enter number 1: -5
+The numbers should be between 0 and 1000
+Enter number 1: 250
+Enter number 2: 999
+Multiplication of 250 and 999 gives 249750
+Enter number 1: 0
+Goodbye!
+```

--- a/chapters/08 functions/08 exercises/05 loop-and-a-half/description/description.nl.md
+++ b/chapters/08 functions/08 exercises/05 loop-and-a-half/description/description.nl.md
@@ -32,3 +32,35 @@ while True:
 
 print( "Tot ziens!" )
 ```
+
+### Opgave
+
+Schrijf een functie `vraag_geldig_getal` waaraan een prompt (`str`) moet
+doorgegeven worden. De functie moet via `getInteger` blijven vragen om een
+geheel getal met de gegeven prompt, tot de gebruiker een waarde tussen 0 en
+1000 (inclusief) invoert; voor elke waarde buiten dat bereik print je
+`De nummers moeten tussen 0 en 1000 liggen` voor je opnieuw vraagt. De functie
+moet het gevalideerde getal (`int`) teruggeven.
+
+Herschrijf bovenstaande code naar een functie `main` die geen argumenten
+neemt, en gebruik daarbij `vraag_geldig_getal` om het probleem hierboven op
+te lossen. Verwijder ook de `exit()` door in de plaats `return` te gebruiken.
+
+### Voorbeeld
+
+```console?lang=python&prompt=>>>
+>>> vraag_geldig_getal("Geef nummer 1: ")
+Geef nummer 1: -42
+De nummers moeten tussen 0 en 1000 liggen
+Geef nummer 1: 314
+314
+
+>>> main()
+Geef nummer 1: -5
+De nummers moeten tussen 0 en 1000 liggen
+Geef nummer 1: 250
+Geef nummer 2: 999
+Vermenigvuldiging van 250 met 999 geeft 249750
+Geef nummer 1: 0
+Tot ziens!
+```

--- a/chapters/18 binary files/06 exercises/02 compression/description/description.nl.md
+++ b/chapters/18 binary files/06 exercises/02 compression/description/description.nl.md
@@ -13,10 +13,10 @@ vijftien hoort, dan geef je dat aan door halve byte met waarde 0 op te
 slaan, gevolgd door de hele byte die het niet-geëncrypte teken bevat. In
 deze opzet is het mogelijk dat de hele byte verdeeld wordt over halve
 bytes van twee opeenvolgende bytes, namelijk de tweede helft van de ene
-byte, en de eerst helft van de tweede byte. Je mag zelf kiezen of je het
-programma schrijft met de Nederlandse of de Engelse letters (het
-verschil in het programma is maar één regel), maar in de rest van deze
-beschrijving en in mijn oplossing gebruik ik de Engelse letters.
+byte, en de eerst helft van de tweede byte. In de rest van deze
+beschrijving, en dus ook in de oplossing die getest wordt, gebruik ik de
+Engelse letters `etaoinshrdlcum` (aangevuld met de spatie als vijftiende
+teken).
 
 Hint: een eenvoudige manier om dit probleem aan te pakken is het bouwen
 van een list van "half-bytes." Voor de tekens die het meest voorkomen,

--- a/chapters/22 inheritance/04 exercises/01 rectangle/description/description.en.md
+++ b/chapters/22 inheritance/04 exercises/01 rectangle/description/description.en.md
@@ -18,3 +18,29 @@ class Rectangle:
     def circumference( self ):
         return 2*(self.w + self.h)
 ```
+
+### Example
+
+```console?lang=python&prompt=>>>
+>>> r = Rectangle(1, 1, 8, 5)
+>>> r
+[(1,1),w=8,h=5]
+>>> print(r)
+[(1,1),w=8,h=5]
+>>> r.area()
+40
+>>> r.circumference()
+26
+
+>>> s = Square(2, 3, 4)
+>>> s
+[(2,3),w=4,h=4]
+>>> print(s)
+[(2,3),w=4,h=4]
+>>> s.area()
+16
+>>> s.circumference()
+16
+>>> isinstance(s, Rectangle)
+True
+```

--- a/chapters/22 inheritance/04 exercises/01 rectangle/description/description.nl.md
+++ b/chapters/22 inheritance/04 exercises/01 rectangle/description/description.nl.md
@@ -18,3 +18,29 @@ class Rechthoek:
     def omtrek( self ):
         return 2*(self.b + self.h)
 ```
+
+### Voorbeeld
+
+```console?lang=python&prompt=>>>
+>>> r = Rechthoek(1, 1, 8, 5)
+>>> r
+[(1,1),b=8,h=5]
+>>> print(r)
+[(1,1),b=8,h=5]
+>>> r.oppervlakte()
+40
+>>> r.omtrek()
+26
+
+>>> v = Vierkant(2, 3, 4)
+>>> v
+[(2,3),b=4,h=4]
+>>> print(v)
+[(2,3),b=4,h=4]
+>>> v.oppervlakte()
+16
+>>> v.omtrek()
+16
+>>> isinstance(v, Rechthoek)
+True
+```

--- a/chapters/22 inheritance/04 exercises/02 shape/description/description.en.md
+++ b/chapters/22 inheritance/04 exercises/02 shape/description/description.en.md
@@ -4,3 +4,91 @@ are defined differently, but share with rectangles and squares that they
 have an area and circumference. Define an interface class `Shape`, of
 which `Rectangle` and `Square` are sub(sub)classes. Also define a class
 `Circle` that you derive from `Shape`.
+
+### Assignment
+
+Below I give the `Shape` interface class from the previous exercise,
+together with the `Rectangle` and `Square` classes built on top of it
+(your submission is graded on its own, so it cannot import anything from
+another exercise). `Shape` defines the common interface every shape must
+support: a method `area` and a method `circumference`. `Shape` itself
+does not know how to compute either, so both simply return
+`NotImplemented`.
+
+```python
+class Shape:
+    def area( self ):
+        return NotImplemented
+    def circumference( self ):
+        return NotImplemented
+
+class Rectangle(Shape):
+    def __init__( self, x, y, w, h ):
+        self.x = x
+        self.y = y
+        self.w = w
+        self.h = h
+    def __repr__( self ):
+        return "[({},{}),w={},h={}]".format( self.x, self.y, 
+            self.w, self.h )
+    def area( self ):
+        return self.w * self.h
+    def circumference( self ):
+        return 2*(self.w + self.h)
+
+class Square(Rectangle):
+    def __init__( self, x, y, side ):
+        Rectangle.__init__( self, x, y, side, side )
+```
+
+Now also create a class `Circle` that inherits directly from `Shape`
+(not from `Rectangle` or `Square`). A circle is created with the `x` and
+`y` coordinate of its center, and a radius `r`. If a circle is passed to
+the builtin functions `repr` or `str`, the string
+`"[({},{}),r={}]".format(x, y, r)` must be returned. Its `area` method
+must return $$\pi r^2$$ and its `circumference` method must return
+$$2\pi r$$ (use `math.pi`).
+
+### Example
+
+```console?lang=python&prompt=>>>
+>>> shape = Shape()
+>>> shape.area()
+NotImplemented
+>>> shape.circumference()
+NotImplemented
+
+>>> r = Rectangle(1, 1, 8, 5)
+>>> r
+[(1,1),w=8,h=5]
+>>> r.area()
+40
+>>> r.circumference()
+26
+>>> isinstance(r, Shape)
+True
+
+>>> s = Square(2, 3, 4)
+>>> s
+[(2,3),w=4,h=4]
+>>> s.area()
+16
+>>> s.circumference()
+16
+>>> isinstance(s, Rectangle)
+True
+>>> isinstance(s, Shape)
+True
+
+>>> c = Circle(0, 0, 3)
+>>> c
+[(0,0),r=3]
+>>> c.area()
+28.274333882308138
+>>> c.circumference()
+18.84955592153876
+>>> isinstance(c, Shape)
+True
+>>> isinstance(c, Rectangle)
+False
+```

--- a/chapters/22 inheritance/04 exercises/02 shape/description/description.nl.md
+++ b/chapters/22 inheritance/04 exercises/02 shape/description/description.nl.md
@@ -5,3 +5,92 @@ gemeen hebben dat ze een oppervlakte en een omtrek hebben. Definieer een
 interface class `Vorm`, waarvan `Rechthoek` en `Vierkant`
 sub(sub)classes zijn. Definieer ook een class `Cirkel` die je afleidt
 van `Vorm`.
+
+### Opgave
+
+Hieronder geef ik de interface class `Vorm` uit de vorige opgave,
+samen met de classes `Rechthoek` en `Vierkant` die erop voortbouwen (je
+oplossing wordt op zichzelf beoordeeld, en kan dus niets importeren uit
+een andere opgave). `Vorm` legt het gemeenschappelijke interface vast
+dat elke vorm moet ondersteunen: een methode `oppervlakte` en een
+methode `omtrek`. `Vorm` zelf weet niet hoe ze die moet berekenen,
+dus geven beide gewoon `NotImplemented` terug.
+
+```python
+class Vorm:
+    def oppervlakte( self ):
+        return NotImplemented
+    def omtrek( self ):
+        return NotImplemented
+
+class Rechthoek(Vorm):
+    def __init__( self, x, y, b, h ):
+        self.x = x
+        self.y = y
+        self.b = b
+        self.h = h
+    def __repr__( self ):
+        return "[({},{}),b={},h={}]".format( self.x, self.y, 
+            self.b, self.h )
+    def oppervlakte( self ):
+        return self.b * self.h
+    def omtrek( self ):
+        return 2*(self.b + self.h)
+
+class Vierkant(Rechthoek):
+    def __init__( self, x, y, zijde ):
+        Rechthoek.__init__( self, x, y, zijde, zijde )
+```
+
+Creëer nu ook een class `Cirkel` die rechtstreeks erft van `Vorm` (niet
+van `Rechthoek` of `Vierkant`). Een cirkel wordt aangemaakt met de `x`-
+en `y`-coördinaat van haar middelpunt, en een straal `straal`. Als een
+cirkel doorgegeven wordt aan de ingebouwde functies `repr` of `str`,
+dan moet de string `"[({},{}),straal={}]".format(x, y, straal)`
+teruggegeven worden. Haar methode `oppervlakte` moet $$\pi \cdot
+straal^2$$ teruggeven en haar methode `omtrek` moet $$2\pi \cdot
+straal$$ teruggeven (gebruik `math.pi`).
+
+### Voorbeeld
+
+```console?lang=python&prompt=>>>
+>>> vorm = Vorm()
+>>> vorm.oppervlakte()
+NotImplemented
+>>> vorm.omtrek()
+NotImplemented
+
+>>> r = Rechthoek(1, 1, 8, 5)
+>>> r
+[(1,1),b=8,h=5]
+>>> r.oppervlakte()
+40
+>>> r.omtrek()
+26
+>>> isinstance(r, Vorm)
+True
+
+>>> v = Vierkant(2, 3, 4)
+>>> v
+[(2,3),b=4,h=4]
+>>> v.oppervlakte()
+16
+>>> v.omtrek()
+16
+>>> isinstance(v, Rechthoek)
+True
+>>> isinstance(v, Vorm)
+True
+
+>>> c = Cirkel(0, 0, 3)
+>>> c
+[(0,0),straal=3]
+>>> c.oppervlakte()
+28.274333882308138
+>>> c.omtrek()
+18.84955592153876
+>>> isinstance(c, Vorm)
+True
+>>> isinstance(c, Rechthoek)
+False
+```

--- a/chapters/22 inheritance/04 exercises/03 prisoner/description/description.en.md
+++ b/chapters/22 inheritance/04 exercises/03 prisoner/description/description.en.md
@@ -18,7 +18,8 @@ implement the `lastmove()` method, and extend the `__init__()` method.
 
 Implement the following strategies:
 
--   `Random` just plays COOPERATE or DEFECT at random.
+-   `Random` just plays COOPERATE or DEFECT at random. It does not matter
+    how you pick the move, as long as both moves really can come up.
 
 -   `AlwaysDefect` always plays DEFECT.
 
@@ -31,7 +32,8 @@ Implement the following strategies:
     COOPERATEs.
 
 -   `Majority` starts with COOPERATE, then plays what the opponent
-    played on the majority of the previous moves.
+    played on the majority of the previous moves. If the opponent played
+    COOPERATE and DEFECT equally often, `Majority` plays COOPERATE.
 
 If you want to implement more strategies, be my guest. Test out some of
 the strategies against each other by filling in the assignments for
@@ -83,3 +85,41 @@ for i in range( ROUNDS ):
 print( "End score of", strategy1.name, "is", strategy1.score )
 print( "End score of", strategy2.name, "is", strategy2.score )
 ```
+
+### Example
+
+```console?lang=python&prompt=>>>
+>>> tia = TitForTat('Tia')
+>>> tia.choice()
+'C'
+>>> tia.lastmove('C', 'D')
+>>> tia.choice()
+'D'
+>>> tia.lastmove('C', 'C')
+>>> tia.choice()
+'C'
+>>> tia.incscore(3)
+>>> tia.score
+3
+
+>>> mia = Majority('Mia')
+>>> mia.choice()
+'C'
+>>> mia.lastmove('C', 'D')
+>>> mia.choice()
+'D'
+>>> mia.lastmove('C', 'C')
+>>> mia.choice()
+'C'
+>>> mia.lastmove('C', 'D')
+>>> mia.choice()
+'D'
+
+>>> rae = Random('Rae')
+>>> rae.choice() in (COOPERATE, DEFECT)
+True
+```
+
+The third choice `Mia` makes shows the tie-break: the opponent played
+COOPERATE once and DEFECT once, so there is no majority and `Majority`
+falls back on COOPERATE.

--- a/chapters/22 inheritance/04 exercises/03 prisoner/description/description.nl.md
+++ b/chapters/22 inheritance/04 exercises/03 prisoner/description/description.nl.md
@@ -25,7 +25,8 @@ uitbreiden.
 
 Implementeer de volgende strategieën:
 
--   `Random` speelt COOPERATIE of DEFECTIE per toeval
+-   `Random` speelt COOPERATIE of DEFECTIE per toeval. Het maakt niet uit
+    hoe je de zet kiest, zolang beide zetten er echt uit kunnen komen
 
 -   `AltijdD` speelt altijd DEFECTIE
 
@@ -39,7 +40,9 @@ Implementeer de volgende strategieën:
     rondes, en anders COOPERATIE
 
 -   `Meerderheid` start met COOPERATIE, en speelt dan wat de
-    tegenstander speelde in de meerderheid van de voorgaande rondes
+    tegenstander speelde in de meerderheid van de voorgaande rondes. Als
+    de tegenstander even vaak COOPERATIE als DEFECTIE speelde, dan speelt
+    `Meerderheid` COOPERATIE
 
 Als je nog meer strategieën wilt implementeren, mag dat natuurlijk. Test
 sommige strategieën uit tegen elkaar door ze in te vullen bij de
@@ -91,3 +94,41 @@ for i in range( RONDES ):
 print( "Eind score", strategie1.name, "is", strategie1.score )
 print( "Eind score", strategie2.name, "is", strategie2.score )
 ```
+
+### Voorbeeld
+
+```console?lang=python&prompt=>>>
+>>> tia = OogOmOog('Tia')
+>>> tia.keuze()
+'C'
+>>> tia.laatstezet('C', 'D')
+>>> tia.keuze()
+'D'
+>>> tia.laatstezet('C', 'C')
+>>> tia.keuze()
+'C'
+>>> tia.plusscore(3)
+>>> tia.score
+3
+
+>>> mia = Meerderheid('Mia')
+>>> mia.keuze()
+'C'
+>>> mia.laatstezet('C', 'D')
+>>> mia.keuze()
+'D'
+>>> mia.laatstezet('C', 'C')
+>>> mia.keuze()
+'C'
+>>> mia.laatstezet('C', 'D')
+>>> mia.keuze()
+'D'
+
+>>> rae = Random('Rae')
+>>> rae.keuze() in (COOPERATIE, DEFECTIE)
+True
+```
+
+De derde keuze van `Mia` toont hoe een gelijke stand beslecht wordt: de
+tegenstander speelde één keer COOPERATIE en één keer DEFECTIE, dus is er
+geen meerderheid en valt `Meerderheid` terug op COOPERATIE.

--- a/chapters/22 inheritance/04 exercises/03 prisoner/evaluation/2.out
+++ b/chapters/22 inheritance/04 exercises/03 prisoner/evaluation/2.out
@@ -5,4 +5,6 @@ independent examples: false
     <class from="Strategy" to="Strategie" />
     <class from="Random" to="Random" />
     <method from="choice" to="keuze" />
+    <method from="lastmove" to="laatstezet" />
+    <method from="incscore" to="plusscore" />
 </LANGUAGE>

--- a/chapters/22 inheritance/04 exercises/03 prisoner/evaluation/6.in
+++ b/chapters/22 inheritance/04 exercises/03 prisoner/evaluation/6.in
@@ -116,57 +116,68 @@ True
 >>> isinstance(deon, Strategy) and isinstance(femke, Strategy)
 True
 
->>> random.seed(4242) # doctest: +NEWCONTEXT
->>> kai = Random('Kai')
->>> lina = Majority('Lina')
->>> c1 = kai.choice()
->>> c2 = lina.choice()
->>> c1, c2
-('D', 'C')
->>> kai.incscore(6)
->>> lina.incscore(0)
->>> kai.lastmove(c1, c2)
->>> lina.lastmove(c2, c1)
->>> kai.score
-6
->>> lina.score
-0
->>> c1 = kai.choice()
->>> c2 = lina.choice()
+>>> lina = Majority('Lina') # doctest: +NEWCONTEXT
+>>> kai = AlwaysDefect('Kai')
+>>> c1 = lina.choice()
+>>> c2 = kai.choice()
 >>> c1, c2
 ('C', 'D')
->>> kai.incscore(0)
->>> lina.incscore(6)
->>> kai.lastmove(c1, c2)
->>> lina.lastmove(c2, c1)
->>> kai.score
-6
->>> lina.score
-6
->>> c1 = kai.choice()
->>> c2 = lina.choice()
->>> c1, c2
-('C', 'C')
->>> kai.incscore(3)
->>> lina.incscore(3)
->>> kai.lastmove(c1, c2)
->>> lina.lastmove(c2, c1)
->>> kai.score
-9
->>> lina.score
-9
->>> c1 = kai.choice()
->>> c2 = lina.choice()
->>> c1, c2
-('D', 'C')
->>> kai.incscore(6)
 >>> lina.incscore(0)
->>> kai.lastmove(c1, c2)
->>> lina.lastmove(c2, c1)
->>> kai.score
-15
+>>> kai.incscore(6)
+>>> lina.lastmove(c1, c2)
+>>> kai.lastmove(c2, c1)
 >>> lina.score
+0
+>>> kai.score
+6
+>>> c1 = lina.choice()
+>>> c2 = kai.choice()
+>>> c1, c2
+('D', 'D')
+>>> lina.incscore(1)
+>>> kai.incscore(1)
+>>> lina.lastmove(c1, c2)
+>>> kai.lastmove(c2, c1)
+>>> lina.score
+1
+>>> kai.score
+7
+>>> c1 = lina.choice()
+>>> c2 = kai.choice()
+>>> c1, c2
+('D', 'D')
+>>> lina.incscore(1)
+>>> kai.incscore(1)
+>>> lina.lastmove(c1, c2)
+>>> kai.lastmove(c2, c1)
+>>> lina.score
+2
+>>> kai.score
+8
+>>> c1 = lina.choice()
+>>> c2 = kai.choice()
+>>> c1, c2
+('D', 'D')
+>>> lina.incscore(1)
+>>> kai.incscore(1)
+>>> lina.lastmove(c1, c2)
+>>> kai.lastmove(c2, c1)
+>>> lina.score
+3
+>>> kai.score
 9
->>> isinstance(kai, Strategy) and isinstance(lina, Strategy)
+>>> c1 = lina.choice()
+>>> c2 = kai.choice()
+>>> c1, c2
+('D', 'D')
+>>> lina.incscore(1)
+>>> kai.incscore(1)
+>>> lina.lastmove(c1, c2)
+>>> kai.lastmove(c2, c1)
+>>> lina.score
+4
+>>> kai.score
+10
+>>> isinstance(lina, Strategy) and isinstance(kai, Strategy)
 True
 

--- a/chapters/22 inheritance/04 exercises/03 prisoner/evaluation/6.out
+++ b/chapters/22 inheritance/04 exercises/03 prisoner/evaluation/6.out
@@ -7,7 +7,6 @@ independent examples: false
     <class from="TitForTwoTats" to="OogOmTweeOgen" />
     <class from="AlwaysDefect" to="AltijdD" />
     <class from="Majority" to="Meerderheid" />
-    <class from="Random" to="Random" />
     <method from="choice" to="keuze" />
     <method from="lastmove" to="laatstezet" />
     <method from="incscore" to="plusscore" />

--- a/chapters/22 inheritance/04 exercises/03 prisoner/preparation/generator.py
+++ b/chapters/22 inheritance/04 exercises/03 prisoner/preparation/generator.py
@@ -91,28 +91,54 @@ for index, (name, ncalls, lastmoves, increments) in enumerate(scenarios):
     print()
 
 # ---------------------------------------------------------------------
-# tab 2: Random -- overrides choice() using the random module; tested
-# with a fixed seed so the outcomes are reproducible
+# tab 2: Random -- overrides choice() using the random module, and
+# inherits everything else unchanged from Strategy. A strategy that
+# picks its move at random can call the random module in any reasonable
+# way, so seeding the random module and pinning down the exact sequence
+# of moves that follows would reject correct solutions that happen to
+# consume the random stream differently. The shape of the returned
+# moves is checked instead, by a custom output processor.
 # ---------------------------------------------------------------------
+
+# read the custom output processor that checks the return value of choice()
+with open('randomchecker.py', 'r', encoding='utf-8') as handle:
+    CHECKER = handle.read().strip()
+
+DEFINITION = '<DEFINITION>\n{}\n</DEFINITION>\n'.format(CHECKER)
+PROCESSOR = '<OUTPUTPROCESSOR>\nRandomMoveChecker(expected_type=str)\n</OUTPUTPROCESSOR>'
+
 sys.stdout = open(os.path.join('..', 'evaluation', '2.in'), 'w', encoding='utf-8')
 
-seeds_and_names = [(11, 'Rae'), (202, 'Noor'), (37, ''), (9001, 'Kofi'), (555, 'Ida')]
+scenarios = [
+    ('Rae', [('C', 'D')], [6]),
+    ('', [('D', 'D')], [1, 1]),
+    ('Kofi', [], [3]),
+]
 
-for index, (seed, name) in enumerate(seeds_and_names):
+for index, (name, lastmoves, increments) in enumerate(scenarios):
 
     varname = f'gambler_{index + 1:02d}'
-    print(f'>>> random.seed({seed}) # doctest: +NEWCONTEXT')
-    random.seed(seed)
+    obj = test_instantiation(Random, name, varname=varname)
 
-    if name:
-        print(f'>>> {varname} = Random({name!r})')
-        obj = Random(name)
-    else:
-        print(f'>>> {varname} = Random()')
-        obj = Random()
+    test_property(obj, 'name', varname=varname)
+    test_property(obj, 'score', varname=varname)
 
-    for _ in range(5):
-        test_method(obj, 'choice', varname=varname)
+    # Random adds nothing but choice(), so it must remain a Strategy
+    print(f'>>> isinstance({varname}, Strategy)')
+    print(repr(isinstance(obj, Strategy)))
+
+    # the definition of the custom output processor is only needed once,
+    # after which it stays available in the doctest scope
+    processor = (DEFINITION if index == 0 else '') + PROCESSOR
+    test_method(obj, 'choice', varname=varname, processor=processor)
+
+    for mymove, oppmove in lastmoves:
+        test_method(obj, 'lastmove', mymove, oppmove, varname=varname)
+
+    for n in increments:
+        test_method(obj, 'incscore', n, varname=varname)
+
+    test_property(obj, 'score', varname=varname)
 
     print()
 
@@ -203,7 +229,12 @@ for index, (name, opponent_moves) in enumerate(scenarios):
 # of the actual game against each other, driven purely through the
 # common Strategy interface (choice/incscore/lastmove); this exercises
 # polymorphism: the same calling code works correctly regardless of
-# which concrete Strategy subclass is behind strategy1/strategy2
+# which concrete Strategy subclass is behind strategy1/strategy2. Only
+# deterministic strategies are matched up here: pitting Random against
+# another strategy would make the outcome of the match depend on the way
+# a solution happens to consume the random stream, which is exactly what
+# tab 2 avoids. Random playing an actual match adds nothing anyway,
+# since it inherits everything but choice() from Strategy.
 # ---------------------------------------------------------------------
 sys.stdout = open(os.path.join('..', 'evaluation', '6.in'), 'w', encoding='utf-8')
 
@@ -237,24 +268,17 @@ def play_round(varname1, obj1, varname2, obj2):
     print(repr(obj2.score))
 
 matches = [
-    ('TitForTat', 'Tessa', 'AlwaysDefect', 'Aiden', None, 4),
-    ('TitForTwoTats', 'Deon', 'AlwaysDefect', 'Femke', None, 5),
-    ('Random', 'Kai', 'Majority', 'Lina', 4242, 4),
+    ('TitForTat', 'Tessa', 'AlwaysDefect', 'Aiden', 4),
+    ('TitForTwoTats', 'Deon', 'AlwaysDefect', 'Femke', 5),
+    ('Majority', 'Lina', 'AlwaysDefect', 'Kai', 5),
 ]
 
-for varname1_class, name1, varname2_class, name2, seed, rounds in matches:
-
-    if seed is not None:
-        print(f'>>> random.seed({seed}) # doctest: +NEWCONTEXT')
-        random.seed(seed)
-        newcontext = False
-    else:
-        newcontext = True
+for varname1_class, name1, varname2_class, name2, rounds in matches:
 
     varname1 = name1.lower()
     varname2 = name2.lower()
 
-    context = ' # doctest: +NEWCONTEXT' if newcontext else ''
+    context = ' # doctest: +NEWCONTEXT'
     print(f'>>> {varname1} = {varname1_class}({name1!r}){context}')
     obj1 = eval(varname1_class)(name1)
     print(f'>>> {varname2} = {varname2_class}({name2!r})')

--- a/chapters/22 inheritance/04 exercises/03 prisoner/preparation/randomchecker.py
+++ b/chapters/22 inheritance/04 exercises/03 prisoner/preparation/randomchecker.py
@@ -1,12 +1,3 @@
->>> gambler_01 = Random('Rae') # doctest: +NEWCONTEXT
->>> gambler_01.name
-'Rae'
->>> gambler_01.score
-0
->>> isinstance(gambler_01, Strategy)
-True
->>> gambler_01.choice()
-<DEFINITION>
 class RandomMoveChecker(OutputProcessor):
 
     """
@@ -87,47 +78,3 @@ class RandomMoveChecker(OutputProcessor):
 
         # generated return value passed all tests
         return True
-</DEFINITION>
-<OUTPUTPROCESSOR>
-RandomMoveChecker(expected_type=str)
-</OUTPUTPROCESSOR>
-'D'
->>> gambler_01.lastmove('C', 'D')
->>> gambler_01.incscore(6)
->>> gambler_01.score
-6
-
->>> gambler_02 = Random('') # doctest: +NEWCONTEXT
->>> gambler_02.name
-''
->>> gambler_02.score
-0
->>> isinstance(gambler_02, Strategy)
-True
->>> gambler_02.choice()
-<OUTPUTPROCESSOR>
-RandomMoveChecker(expected_type=str)
-</OUTPUTPROCESSOR>
-'D'
->>> gambler_02.lastmove('D', 'D')
->>> gambler_02.incscore(1)
->>> gambler_02.incscore(1)
->>> gambler_02.score
-2
-
->>> gambler_03 = Random('Kofi') # doctest: +NEWCONTEXT
->>> gambler_03.name
-'Kofi'
->>> gambler_03.score
-0
->>> isinstance(gambler_03, Strategy)
-True
->>> gambler_03.choice()
-<OUTPUTPROCESSOR>
-RandomMoveChecker(expected_type=str)
-</OUTPUTPROCESSOR>
-'D'
->>> gambler_03.incscore(3)
->>> gambler_03.score
-3
-

--- a/chapters/27 various useful modules/06 exercises/01 counter/description/description.en.md
+++ b/chapters/27 various useful modules/06 exercises/01 counter/description/description.en.md
@@ -1,2 +1,15 @@
 Use the `Counter` class to list
 the five most common letters in a text, with their counts.
+
+### Assignment
+
+Write a function `most_common_letters` that takes a string (`str`) and returns a list of `(letter, count)` tuples for the five most common letters in the text. Only letters count: characters that are not letters must be ignored, and case must be ignored (uppercase and lowercase versions of the same letter are added together, and reported in lowercase). If two or more letters occur equally often, list them in the order they first appear in the text. If the text contains fewer than five distinct letters, return only those that occur.
+
+### Example
+
+```console?lang=python&prompt=>>>
+>>> most_common_letters('mississippi')
+[('i', 4), ('s', 4), ('p', 2), ('m', 1)]
+>>> most_common_letters('AaAaBbBcCcC')
+[('a', 4), ('c', 4), ('b', 3)]
+```

--- a/chapters/27 various useful modules/06 exercises/01 counter/description/description.nl.md
+++ b/chapters/27 various useful modules/06 exercises/01 counter/description/description.nl.md
@@ -1,3 +1,16 @@
 Gebruik de `Counter` class om de
 vijf meest voorkomende letters in een tekst te tonen, inclusief hun
 tellingen.
+
+### Opgave
+
+Schrijf een functie `meest_voorkomende_letters` die een string (`str`) als argument neemt en een lijst van `(letter, aantal)`-tuples teruggeeft voor de vijf meest voorkomende letters in de tekst. Enkel letters tellen mee: tekens die geen letter zijn, moeten genegeerd worden, en er wordt geen onderscheid gemaakt tussen hoofd- en kleine letters (beide versies van eenzelfde letter worden samengeteld, en gerapporteerd als kleine letter). Als twee of meer letters even vaak voorkomen, zet je ze in de volgorde waarin ze het eerst voorkomen in de tekst. Als de tekst minder dan vijf verschillende letters bevat, geef je enkel de letters terug die effectief voorkomen.
+
+### Voorbeeld
+
+```console?lang=python&prompt=>>>
+>>> meest_voorkomende_letters('mississippi')
+[('i', 4), ('s', 4), ('p', 2), ('m', 1)]
+>>> meest_voorkomende_letters('AaAaBbBcCcC')
+[('a', 4), ('c', 4), ('b', 3)]
+```

--- a/chapters/27 various useful modules/06 exercises/02 mode/description/description.en.md
+++ b/chapters/27 various useful modules/06 exercises/02 mode/description/description.en.md
@@ -6,3 +6,20 @@ that have the highest count, even if that entails that you print more
 than one number. By definition, for a number to be the mode it must
 occur at least twice; so if every number only occurs once, there is no
 mode. Hint: Consider using the `Counter` class to construct the mode.
+
+### Assignment
+
+Write a function `mode` that takes a list of integers and returns a sorted list of the number(s) that occur most often. A number only counts as a mode if it occurs at least twice; if every number in the list occurs only once, or the list is empty, there is no mode and the function must return an empty list. If multiple numbers are tied for the highest count, return all of them, sorted from low to high.
+
+Use this function in your program: keep asking the user for numbers until they enter 0, then print the mean, median, and mode of the numbers that were entered (not counting the final 0). The `statistics` module can be used for the mean and median.
+
+### Example
+
+```console?lang=python&prompt=>>>
+>>> mode([4, 8, 15, 16, 23, 8, 4, 8])
+[8]
+>>> mode([7, 2, 9, 2, 9, 3])
+[2, 9]
+>>> mode([5, 10, 15])
+[]
+```

--- a/chapters/27 various useful modules/06 exercises/02 mode/description/description.nl.md
+++ b/chapters/27 various useful modules/06 exercises/02 mode/description/description.nl.md
@@ -7,3 +7,20 @@ het meest voorkomen, zelfs als dat betekent dat je meer dan één getal
 moet tonen. Per definitie moet een getal dat modus is minstens twee keer
 voorkomen; als ieder getal uniek is, is er geen modus. Hint: Je kunt de
 `Counter` class gebruiken om de modus te construeren.
+
+### Opgave
+
+Schrijf een functie `modus` die een lijst van gehele getallen als argument neemt en een gesorteerde lijst teruggeeft van het getal (of de getallen) dat het vaakst voorkomt. Een getal telt enkel als modus als het minstens twee keer voorkomt; als ieder getal in de lijst maar één keer voorkomt, of als de lijst leeg is, is er geen modus en geeft de functie een lege lijst terug. Als meerdere getallen samen de hoogste telling hebben, geef je ze allemaal terug, gesorteerd van laag naar hoog.
+
+Gebruik deze functie in je programma: blijf de gebruiker vragen om getallen totdat die een nul ingeeft, en toon dan het gemiddelde, de mediaan, en de modus van de ingegeven getallen (zonder de afsluitende nul mee te tellen). Je kunt de `statistics` module gebruiken voor het gemiddelde en de mediaan.
+
+### Voorbeeld
+
+```console?lang=python&prompt=>>>
+>>> modus([4, 8, 15, 16, 23, 8, 4, 8])
+[8]
+>>> modus([7, 2, 9, 2, 9, 3])
+[2, 9]
+>>> modus([5, 10, 15])
+[]
+```


### PR DESCRIPTION
## Summary

Follow-up to #332. A review of all 29 exercises added there checked whether each description actually specifies what's graded (exact function/class contract, plus a worked example) — 23 were fine, but 6 needed fixes, and one of those turned up a real test-suite bug rather than just a documentation gap.

<details>
<summary>What was wrong and what changed (6 exercises)</summary>

- **`08 functions/05 loop-and-a-half`** — no worked example at all, and never named the required `get_valid_number`/`vraag_geldig_getal` helper or `main()`, or their signatures. Added an Assignment section + a worked transcript traced against the real solution.
- **`18 binary files/02 compression`** (Dutch only) — actively wrong: told students they could freely choose Dutch or English letter frequencies, but the tests only accept the English mapping. Corrected to match what's graded.
- **`22 inheritance/01 rectangle`** — no worked example/output at all; `Square`'s 3-arg constructor was never demonstrated even though `isinstance` checks against it are tested. Added a worked example.
- **`22 inheritance/02 shape`** — gave no code at all despite testing `Rectangle`/`Square` instances directly (whose repr format is only defined in the sibling `01 rectangle` exercise, and each exercise is graded standalone). `Circle`'s constructor and repr format (including the Dutch `straal=` field name) appeared nowhere. Added the `Rectangle`/`Square` code inline (matching this repo's convention for standalone-graded follow-on exercises, e.g. `21 operator overloading/03 war`), spelled out `Circle`'s contract, added a worked example.
- **`27 various useful modules/01 counter`** — the one you originally flagged as too sparse: no function name/signature, no return format, no letter/case/punctuation handling rule, no tie-break rule, no example. Fully specified now.
- **`27 various useful modules/02 mode`** — described only the interactive program, never stated the graded function is `mode(numbers)` returning a sorted list of ints. Fully specified now.

</details>

<details>
<summary>Real bug: prisoner's Random strategy tests (not just a description fix)</summary>

`22 inheritance/03 prisoner`'s `Random` strategy tab (and part of the `Match` tab) seeded Python's `random` module and asserted one *exact* sequence of returned moves. That only reproduces if a student's implementation calls `random.choice()` in that precise form — a logically correct "play randomly" implementation using a different valid approach (e.g. `random.random() < 0.5`, or the tuple in a different order) would fail despite being correct.

Replaced the seeded exact-sequence checks with a custom `OutputProcessor` (`preparation/randomchecker.py`, using this repo's existing `<DEFINITION>`/`<OUTPUTPROCESSOR>` pattern from the shuffled card deck and battleship exercises) that checks the *shape* of the behavior instead: 100 calls, every one a valid move, each move appearing at least 10 times. A truly random strategy fails only by ~1-in-10¹⁷ chance; a strategy that always returns the same move is still always caught. The `Match` tab's `Random`-vs-`Majority` game (same underlying bug) was replaced with a deterministic `Majority`-vs-`AlwaysDefect` game, which also adds coverage `Majority` never had in that tab.

Also documented `Majority`'s previously-untested-in-prose tie-break rule (ties go to COOPERATE) and added a worked example to both descriptions.

Verified independently against the real judge (not just by the fix itself): reference solutions still pass in both languages, an alternative-but-valid `Random` implementation (`random.random() < 0.5` instead of `random.choice`) now passes — confirming the fragility is actually fixed — and a broken implementation that always returns the same move is still rejected, confirming the check didn't just become permissive.

</details>

## Test plan

- [x] Every changed example transcript traced/run against the real `solution.en.py`/`solution.nl.py` to confirm accuracy
- [x] `18 binary files/02 compression`: confirmed via `grep` that both solutions and the evaluation data hardcode the English letters, so the corrected description now matches what's graded
- [x] `22 inheritance/03 prisoner`: reference solutions re-verified against the real judge in both languages after the test-suite change (0 failures); an alternative-but-valid `Random` implementation now passes; a broken always-same-move implementation is still rejected
- [x] `git diff` confirms no `solution/`/`evaluation/` changes for the 5 exercises where only descriptions needed fixing
