### PR TITLE
Clean up escaped curly braces in subdirectories description

### DIFF
--- a/chapters/23 iterators and generators/05 exercises/06 subdirectories/description/description.en.md
+++ b/chapters/23 iterators and generators/05 exercises/06 subdirectories/description/description.en.md
@@ -1,7 +1,7 @@
 Write a program that
 produces all possible sub-dictionaries from a dictionary, and stores
-them in a list. For instance, if the dictionary is `\{"a":1,"b":2\}`,
-the program produces `[\{\},\{"a":1\},\{"b":2\},\{"a":1,"b":2\}]` (the
+them in a list. For instance, if the dictionary is `{"a": 1, "b": 2}`,
+the program produces `[{}, {"a": 1}, {"b": 2}, {"a": 1, "b": 2}]` (the
 ordering of the list does not matter). Again, use the `itertools`
 module.
 

--- a/chapters/23 iterators and generators/05 exercises/06 subdirectories/description/description.nl.md
+++ b/chapters/23 iterators and generators/05 exercises/06 subdirectories/description/description.nl.md
@@ -1,8 +1,8 @@
 Schrijf een programma
 dat alle mogelijke sub-dictionaries produceert van een dictionary, en ze
-opslaat in een list. Bijvoorbeeld, als de dictionary `\{"a":1,"b":2\}`
+opslaat in een list. Bijvoorbeeld, als de dictionary `{"a": 1, "b": 2}`
 is, dan produceert het programma
-`[\{\},\{"a":1\},\{"b":2\},\{"a":1,"b":2\}]` (de volgorde in de list
+`[{}, {"a": 1}, {"b": 2}, {"a": 1, "b": 2}]` (de volgorde in de list
 maakt niet uit). Gebruik de `itertools` module.
 
 ### Opgave


### PR DESCRIPTION
## Summary

Small follow-up that missed the window on #333 (pushed right after that PR was merged, so it never made it into `master`).

`23 iterators and generators/06 subdirectories`'s intro paragraph had leftover backslash-escaped curly braces from the original book text (`` \{"a":1,"b":2\} ``), rendering literally instead of as clean dict literals — inconsistent with the properly-formatted `### Example` section right below it. Removed the unnecessary escaping and matched the spacing style already used there. This was the only file in the repo with this pattern.

## Test plan

- [x] Confirmed no other file in `chapters/` has the same escaped-brace pattern (`grep -rl '\{'`)
- [x] Description-only change, no `solution/`/`evaluation/` touched
