### PR TITLE
Reject a == 0 in the chapter 6 quadratic equations exercise

### DIFF
--- a/chapters/06 conditions/05 exercises/04 quadratic equations/description/description.en.md
+++ b/chapters/06 conditions/05 exercises/04 quadratic equations/description/description.en.md
@@ -12,13 +12,13 @@ is called the **discriminant** of the quadratic equation. The sign of $$\Delta$$
 
 - if $$\Delta > 0$$, then there are two distinct real-valued solutions ($$x_1 \neq x_2$$)
 
-- als $$\Delta = 0$$, then both real-valued solutions are the same ($$x_1 = x_2$$)
+- if $$\Delta = 0$$, then both real-valued solutions are the same ($$x_1 = x_2$$)
 
-- als $$\Delta < 0$$, then there are no real-valued solutions
+- if $$\Delta < 0$$, then there are no real-valued solutions
 
 The real-valued solutions can be determined as:
  
-$$x_{1} = \frac{-b - \sqrt{\Delta}}{2a}\ \ \ \text{en}\ \ \ x_{2} = \frac{-b + \sqrt{\Delta}}{2a}$$
+$$x_{1} = \frac{-b - \sqrt{\Delta}}{2a}\ \ \ \text{and}\ \ \ x_{2} = \frac{-b + \sqrt{\Delta}}{2a}$$
 
 ### Input
 
@@ -26,7 +26,7 @@ The three parameters $$a$$, $$b$$ and $$c$$ of a quadratic equation, each on a s
 
 ### Output
 
-A line that indicates the number of different real-valued solutions of the quadratic equation. The solutions themselves must also be mentioned (if they exist).
+A line that indicates the number of different real-valued solutions of the quadratic equation. The solutions themselves must also be mentioned (if they exist). If $$a = 0$$, the given parameters do not describe a quadratic equation, and the output must be `Invalid equation`.
 
 ### Example
 
@@ -41,7 +41,7 @@ A line that indicates the number of different real-valued solutions of the quadr
 #### Output:
 
 ```
-Er zijn 2 reële oplossingen: -5.0 en 1.0
+There are 2 real-valued solutions: -5.0 and 1.0
 ```
 
 ### Example
@@ -57,7 +57,7 @@ Er zijn 2 reële oplossingen: -5.0 en 1.0
 #### Output:
 
 ```
-Er is 1 reële oplossing: 6.0
+There is 1 real-valued solution: 6.0
 ```
 
 ### Example
@@ -73,7 +73,7 @@ Er is 1 reële oplossing: 6.0
 #### Output:
 
 ```
-Er zijn geen reële oplossingen
+There are no real-valued solutions
 ```
 
 ### Example
@@ -89,5 +89,5 @@ Er zijn geen reële oplossingen
 #### Output:
 
 ```
-Ongeldige vergelijking
+Invalid equation
 ```

--- a/chapters/06 conditions/05 exercises/04 quadratic equations/description/description.nl.md
+++ b/chapters/06 conditions/05 exercises/04 quadratic equations/description/description.nl.md
@@ -26,7 +26,7 @@ De drie parameters $$a$$, $$b$$ en $$c$$ van een kwadratische vergelijking, elk 
 
 ### Uitvoer
 
-En regel die aangeeft hoeveel verschillende reële oplossingen de kwadratische vergelijking heeft. De oplossingen zelf moeten ook vermeld worden (als die er zijn).
+Een regel die aangeeft hoeveel verschillende reële oplossingen de kwadratische vergelijking heeft. De oplossingen zelf moeten ook vermeld worden (als die er zijn). Als $$a = 0$$ beschrijven de gegeven parameters geen kwadratische vergelijking, en moet de uitvoer `Ongeldige vergelijking` zijn.
 
 ### Voorbeeld
 

--- a/chapters/06 conditions/05 exercises/04 quadratic equations/evaluation/0.out
+++ b/chapters/06 conditions/05 exercises/04 quadratic equations/evaluation/0.out
@@ -6,10 +6,10 @@ There are 2 real-valued solutions: -1.0 and -0.2857142857142857
 There are 2 real-valued solutions: 3.8284271247461903 and -1.8284271247461903
 There are no real-valued solutions
 There are 2 real-valued solutions: 0.7787192621510002 and -5.778719262151
-There is 1 real-valued solution: -2.0
+Invalid equation
 There are no real-valued solutions
 There are no real-valued solutions
-There is 1 real-valued solution: -0.5
+Invalid equation
 Invalid equation
 There are no real-valued solutions
 There are no real-valued solutions
@@ -21,24 +21,24 @@ There are 2 real-valued solutions: -1.2898979485566355 and -0.31010205144336445
 There are 2 real-valued solutions: -0.8979157616563596 and 3.8979157616563596
 There are 2 real-valued solutions: 3.0 and -1.0
 There are 2 real-valued solutions: -0.0 and -0.2222222222222222
-There is 1 real-valued solution: 1.75
+Invalid equation
 There are no real-valued solutions
-There is 1 real-valued solution: -0.25
+Invalid equation
 There are 2 real-valued solutions: -0.7745966692414834 and 0.7745966692414834
-There is 1 real-valued solution: -1.8
+Invalid equation
 There are 2 real-valued solutions: -0.6861406616345072 and 2.186140661634507
 There are 2 real-valued solutions: 0.7901612677356107 and -0.3615898391641821
 There are no real-valued solutions
 There are 2 real-valued solutions: -0.3333333333333333 and -2.0
 There are 2 real-valued solutions: -4.60849528301415 and 0.10849528301415079
 There are 2 real-valued solutions: -0.6810249675906654 and 0.8810249675906654
-There is 1 real-valued solution: -1.0
-There is 1 real-valued solution: 0.5
-There is 1 real-valued solution: 1.0
+Invalid equation
+Invalid equation
+Invalid equation
 Invalid equation
 There are 2 real-valued solutions: 0.8601470508735444 and -1.8601470508735445
 There are 2 real-valued solutions: 1.4142135623730951 and -1.4142135623730951
-There is 1 real-valued solution: -4.5
+Invalid equation
 There are 2 real-valued solutions: 1.602628850977318 and -0.9359621843106515
 Invalid equation
 There are no real-valued solutions
@@ -61,6 +61,6 @@ ignore fp rounding: -6
     <fixed from="There are 2 real-valued solutions" to="Er zijn 2 reële oplossingen" />
     <fixed from="There are no real-valued solutions" to="Er zijn geen reële oplossingen" />
     <fixed from=" and " to=" en " detect="false" />
-    <fixed from="Solutions" to="Oplossingen" />
+    <fixed from="Solutions" to="Oplossingen" detect="false" />
 </LANGUAGE>
 

--- a/chapters/06 conditions/05 exercises/04 quadratic equations/preparation/generator.py
+++ b/chapters/06 conditions/05 exercises/04 quadratic equations/preparation/generator.py
@@ -1,6 +1,7 @@
 import os
 import random
 import subprocess
+import sys
 
 # set fixed seed for generating test cases
 random.seed(123456789)
@@ -71,11 +72,11 @@ for stdin in cases:
 
     # generate output to output file
     script = os.path.join(solutiondir, 'solution.en.py')
-    process= subprocess.run(
-        ['python', script],
+    process = subprocess.run(
+        [sys.executable, script],
         input=stdin,
         encoding='utf-8',
-        capture_output=True, shell=True, check=True
+        capture_output=True, check=True
     )
     stdout = process.stdout
 

--- a/chapters/06 conditions/05 exercises/04 quadratic equations/solution/solution.en.py
+++ b/chapters/06 conditions/05 exercises/04 quadratic equations/solution/solution.en.py
@@ -3,13 +3,10 @@ a = float(input())
 b = float(input())
 c = float(input())
 
+# an equation is only quadratic if a is different from zero
 if a == 0:
 
-    if b == 0:
-        print('Invalid equation')
-    else:
-        x1 = -c / b
-        print(f'There is 1 real-valued solution: {x1}')
+    print('Invalid equation')
 
 else:
 

--- a/chapters/06 conditions/05 exercises/04 quadratic equations/solution/solution.nl.py
+++ b/chapters/06 conditions/05 exercises/04 quadratic equations/solution/solution.nl.py
@@ -3,13 +3,10 @@ a = float(input())
 b = float(input())
 c = float(input())
 
+# een vergelijking is enkel kwadratisch als a verschilt van nul
 if a == 0:
 
-    if b == 0:
-        print('Ongeldige vergelijking')
-    else:
-        x1 = -c / b
-        print(f'Er is 1 reële oplossing: {x1}')
+    print('Ongeldige vergelijking')
 
 else:
 

--- a/chapters/08 functions/08 exercises/04 quadratic equations/description/description.en.md
+++ b/chapters/08 functions/08 exercises/04 quadratic equations/description/description.en.md
@@ -12,13 +12,13 @@ is called the **discriminant** of the quadratic equation. The sign of $$\Delta$$
 
 - if $$\Delta > 0$$, then there are two distinct real-valued solutions ($$x_1 \neq x_2$$)
 
-- als $$\Delta = 0$$, then both real-valued solutions are the same ($$x_1 = x_2$$)
+- if $$\Delta = 0$$, then both real-valued solutions are the same ($$x_1 = x_2$$)
 
-- als $$\Delta < 0$$, then there are no real-valued solutions
+- if $$\Delta < 0$$, then there are no real-valued solutions
 
 The real-valued solutions can be determined as:
 
-$$x_{1} = \frac{-b - \sqrt{\Delta}}{2a}\ \ \ \text{en}\ \ \ x_{2} = \frac{-b + \sqrt{\Delta}}{2a}$$
+$$x_{1} = \frac{-b - \sqrt{\Delta}}{2a}\ \ \ \text{and}\ \ \ x_{2} = \frac{-b + \sqrt{\Delta}}{2a}$$
 
 ### Assignment
 


### PR DESCRIPTION
Both claims in #323 hold for `chapters/06 conditions/05 exercises/04 quadratic equations`.

**The solution solved linear equations.** For `a == 0` it only printed the invalid-equation message when `b` was also `0`; otherwise it computed `-c / b` and reported it as one real-valued solution. The description defines a quadratic equation as `ax^2 + bx + c = 0` with `a != 0`, so that contradicts the contract. Nine of the 50 generated cases had `a == 0` and `b != 0`, so the wrong behaviour was baked into `0.out` and a student following the description got rejected.

Fixed on the solution side, since the description is the contract: every `a == 0` now yields the invalid-equation message, and `0.out` was regenerated. I also spelled the rule out in the Output section, because `a == 0` with `b != 0` was covered by no example at all and so was never really specified. Test inputs are untouched, and the 13 degenerate cases already in `0.in` (4 with `b == 0`, 9 with `b != 0`) guard the regression.

**The English description was partly Dutch.** Not only `Ongeldige vergelijking`: all four example outputs were Dutch, plus two `als` bullets and a `\text{en}` in the root formula. All translated. The Dutch description got the new Output sentence and a one-word `En regel` -> `Een regel` typo fix.

The sibling exercise `chapters/08 functions/08 exercises/04 quadratic equations` shares that intro prose, so it carried the same two remnants. Its English description is fixed here as well: `als` -> `if` on both discriminant bullets, and `\text{en}` -> `\text{and}` in the root formula. Descriptions only there, nothing else, see below.

Two things that surfaced while regenerating the evaluation files:

- `preparation/generator.py` passed a list to `subprocess.run` with `shell=True`, so on POSIX it ran a bare `python` and never executed the solution. Running it as committed produced an evaluation file with no test output whatsoever. Now uses `sys.executable` with no shell, and reproduces `0.in` byte for byte.
- The generator emitted the tab-name rule as `<fixed from="Solutions" to="Oplossingen" detect="false" />` while the committed `0.out` had it without `detect="false"`. Aligned `0.out` on the generator: `detect="false"` is the house convention for tab names elsewhere in the repo, and correct, since language detection runs against the submitted source code and a tab name never appears there. Verified behaviour-neutral below.

### Verification

```sh
A="chapters/06 conditions/05 exercises/04 quadratic equations"

# reference solution passes
python3 scripts/verify_pythia_exercise.py "$A" "$A/solution/solution.en.py" --no-pull

# a stub is still rejected
printf '# no implementation\n' > /tmp/stub323.py
python3 scripts/verify_pythia_exercise.py "$A" /tmp/stub323.py --expect-fail --no-pull
```

Results: `50 passed, 0 failed` / `OK: all tests passed`, and `0 passed, 50 failed` / `OK: the solution was rejected, as expected`.

The verify script hardcodes `natural_language=en`, so I drove the judge directly for both languages (`pythia_judge: output`, resolved from `chapters/06 conditions/05 exercises/dirconfig.json`): `solution.nl.py` with `natural_language=nl` gives `accepted: True, status: correct answer, 50 contexts`, and `solution.en.py` with `en` the same. Neither solution carries doctests, so there is nothing to run there.

Chapter 8, since this PR now touches that directory too:

```sh
B="chapters/08 functions/08 exercises/04 quadratic equations"
python3 scripts/verify_pythia_exercise.py "$B" "$B/solution/solution.en.py" --no-pull
python3 scripts/verify_pythia_exercise.py "$B" /tmp/stub323.py --expect-fail --no-pull
```

Results: `100 passed, 0 failed` / `OK: all tests passed`, and `0 passed, 100 failed` / `OK: the solution was rejected, as expected`. Driving the judge directly with `natural_language=nl` (`pythia_judge: doctest` there) accepts `solution.nl.py`: `accepted: True, status: correct answer`, tabs `discriminant` and `oplossingen`, 50 contexts each. Chapter 6 was re-run after the chapter 8 commit and is unchanged: `50 passed, 0 failed`, stub still rejected, Dutch still accepted.

Generator reproduction, in a throwaway dir with `preparation/` and `solution/` copied in:

<details>
<summary>Regenerated 0.out vs. committed (before installing it)</summary>

`0.in` is identical. `0.out` differs in exactly the 9 linear cases plus the settings line:

```
9c9
< Invalid equation
---
> There is 1 real-valued solution: -2.0
11a12
> There is 1 real-valued solution: -0.5
13d13
< Invalid equation
24c24
< Invalid equation
---
> There is 1 real-valued solution: 1.75
26c26
< Invalid equation
---
> There is 1 real-valued solution: -0.25
28c28
< Invalid equation
---
> There is 1 real-valued solution: -1.8
34a35,37
> There is 1 real-valued solution: -1.0
> There is 1 real-valued solution: 0.5
> There is 1 real-valued solution: 1.0
36,38d38
< Invalid equation
< Invalid equation
< Invalid equation
41c41
< Invalid equation
---
> There is 1 real-valued solution: -4.5
64c64
<     <fixed from="Solutions" to="Oplossingen" detect="false" />
---
>     <fixed from="Solutions" to="Oplossingen" />
```

After installing the regenerated file, the generator reproduces both evaluation files byte for byte.

</details>

<details>
<summary>detect="false" is behaviour-neutral</summary>

Ran the Dutch solution against `origin/master`'s `0.out` and against the new one, same judge config: both give `accepted: True, status: correct answer`, and both report the tab as `Solutions` rather than `Oplossingen`. So the tab name was already not being translated before this change (the judge parses the settings block before applying the translation rules); nothing here made it worse. Possibly worth a separate look.

</details>

### The chapter 8 sibling exercise

`chapters/08 functions/08 exercises/04 quadratic equations` gets the description fix only. It does not have defect (a): its generator skips `a == 0` entirely (`while not a: a = random.randint(-10, 10)`), the description never mentions invalid equations, and no test case is degenerate. Its `solutions` function would raise `ZeroDivisionError` on `a == 0`, but nothing ever calls it that way, so there is no student-visible bug and no reason to touch it. Its solutions, evaluation files, generator and config are unchanged. It did carry a milder version of defect (b), which is what is fixed: the same untranslated `als` bullets and `\text{en}` in the shared intro text, but no Dutch output strings. Its Dutch description was already correct and is unchanged.

Closes #323



