### PR TITLE
Stop the enrollments tests from depending on set iteration order

### DIFF
--- a/chapters/20 object orientation/06 exercises/02 enrollments/evaluation/2.in
+++ b/chapters/20 object orientation/06 exercises/02 enrollments/evaluation/2.in
@@ -6,43 +6,43 @@
 >>> harry = Student(29839339, 'Harry', 'Potter', datetime.date(1980, 7, 31))
 >>> hermione = Student(24837367, 'Hermione', 'Granger', datetime.date(1979, 9, 19))
 >>> ron = Student(27373378, 'Ron', 'Weasley', datetime.date(1980, 3, 1))
->>> hermione.enroll(astronomy).courses()
-{Course(238273, 'Astronomy')}
->>> harry.enroll(defence_against_dark_arts).courses()
-{Course(462763, 'Defence Against Dark Arts')}
->>> ron.enroll(dark_arts).courses()
-{Course(746473, 'Dark Arts')}
->>> hermione.enroll(astronomy).enroll(dark_arts).courses()
-{Course(238273, 'Astronomy'), Course(746473, 'Dark Arts')}
->>> hermione.enroll(dark_arts).enroll(charms).courses()
-{Course(238273, 'Astronomy'), Course(746473, 'Dark Arts'), Course(983448, 'Charms')}
->>> harry.enroll(charms).courses()
-{Course(462763, 'Defence Against Dark Arts'), Course(983448, 'Charms')}
->>> harry.enroll(astronomy).courses()
-{Course(462763, 'Defence Against Dark Arts'), Course(983448, 'Charms'), Course(238273, 'Astronomy')}
->>> hermione.enroll(charms).courses()
-{Course(238273, 'Astronomy'), Course(746473, 'Dark Arts'), Course(983448, 'Charms')}
->>> ron.enroll(charms).courses()
-{Course(746473, 'Dark Arts'), Course(983448, 'Charms')}
->>> hermione.enroll(dark_arts).courses()
-{Course(238273, 'Astronomy'), Course(746473, 'Dark Arts'), Course(983448, 'Charms')}
->>> ron.enroll(defence_against_dark_arts).courses()
-{Course(746473, 'Dark Arts'), Course(462763, 'Defence Against Dark Arts'), Course(983448, 'Charms')}
->>> ron.enroll(charms).courses()
-{Course(746473, 'Dark Arts'), Course(462763, 'Defence Against Dark Arts'), Course(983448, 'Charms')}
->>> ron.enroll(defence_against_dark_arts).courses()
-{Course(746473, 'Dark Arts'), Course(462763, 'Defence Against Dark Arts'), Course(983448, 'Charms')}
->>> ron.enroll(astronomy).courses()
-{Course(746473, 'Dark Arts'), Course(462763, 'Defence Against Dark Arts'), Course(983448, 'Charms'), Course(238273, 'Astronomy')}
->>> hermione.enroll(defence_against_dark_arts).courses()
-{Course(238273, 'Astronomy'), Course(462763, 'Defence Against Dark Arts'), Course(746473, 'Dark Arts'), Course(983448, 'Charms')}
->>> ron.enroll(dark_arts).courses()
-{Course(746473, 'Dark Arts'), Course(462763, 'Defence Against Dark Arts'), Course(983448, 'Charms'), Course(238273, 'Astronomy')}
->>> hermione.enroll(charms).courses()
-{Course(238273, 'Astronomy'), Course(462763, 'Defence Against Dark Arts'), Course(746473, 'Dark Arts'), Course(983448, 'Charms')}
->>> harry.enroll(dark_arts).courses()
-{Course(462763, 'Defence Against Dark Arts'), Course(746473, 'Dark Arts'), Course(983448, 'Charms'), Course(238273, 'Astronomy')}
->>> harry.enroll(astronomy).courses()
-{Course(462763, 'Defence Against Dark Arts'), Course(746473, 'Dark Arts'), Course(983448, 'Charms'), Course(238273, 'Astronomy')}
->>> ron.enroll(charms).courses()
-{Course(746473, 'Dark Arts'), Course(462763, 'Defence Against Dark Arts'), Course(983448, 'Charms'), Course(238273, 'Astronomy')}
+>>> hermione.enroll(astronomy).courses() == {astronomy}
+True
+>>> harry.enroll(defence_against_dark_arts).courses() == {defence_against_dark_arts}
+True
+>>> ron.enroll(dark_arts).courses() == {dark_arts}
+True
+>>> hermione.enroll(astronomy).enroll(dark_arts).courses() == {astronomy, dark_arts}
+True
+>>> hermione.enroll(dark_arts).enroll(charms).courses() == {astronomy, charms, dark_arts}
+True
+>>> harry.enroll(charms).courses() == {charms, defence_against_dark_arts}
+True
+>>> harry.enroll(astronomy).courses() == {astronomy, charms, defence_against_dark_arts}
+True
+>>> hermione.enroll(charms).courses() == {astronomy, charms, dark_arts}
+True
+>>> ron.enroll(charms).courses() == {charms, dark_arts}
+True
+>>> hermione.enroll(dark_arts).courses() == {astronomy, charms, dark_arts}
+True
+>>> ron.enroll(defence_against_dark_arts).courses() == {charms, dark_arts, defence_against_dark_arts}
+True
+>>> ron.enroll(charms).courses() == {charms, dark_arts, defence_against_dark_arts}
+True
+>>> ron.enroll(defence_against_dark_arts).courses() == {charms, dark_arts, defence_against_dark_arts}
+True
+>>> ron.enroll(astronomy).courses() == {astronomy, charms, dark_arts, defence_against_dark_arts}
+True
+>>> hermione.enroll(defence_against_dark_arts).courses() == {astronomy, charms, dark_arts, defence_against_dark_arts}
+True
+>>> ron.enroll(dark_arts).courses() == {astronomy, charms, dark_arts, defence_against_dark_arts}
+True
+>>> hermione.enroll(charms).courses() == {astronomy, charms, dark_arts, defence_against_dark_arts}
+True
+>>> harry.enroll(dark_arts).courses() == {astronomy, charms, dark_arts, defence_against_dark_arts}
+True
+>>> harry.enroll(astronomy).courses() == {astronomy, charms, dark_arts, defence_against_dark_arts}
+True
+>>> ron.enroll(charms).courses() == {astronomy, charms, dark_arts, defence_against_dark_arts}
+True

--- a/chapters/20 object orientation/06 exercises/02 enrollments/preparation/generator.py
+++ b/chapters/20 object orientation/06 exercises/02 enrollments/preparation/generator.py
@@ -1,6 +1,6 @@
 import sys
 import datetime
-import importlib
+import importlib.util
 from test_utils import *
 
 # set fixed seed for generating test cases
@@ -125,7 +125,21 @@ for _ in range(20):
         statement += f'.enroll({course_name})'
         student.enroll(course)
     statement += '.courses()'
-    print(statement)
 
-    # generate test result
-    print(f'{student_dict[student_name].courses()!r}')
+    # let the submission itself compare the returned set against a set of the
+    # courses that are already bound in the context, so the expected value of
+    # the test is just the bool True. Two reasons for not simply printing the
+    # repr of the returned set as the expected value:
+    #
+    #   - the iteration order of a set is arbitrary, and printing its repr
+    #     would bake one particular order into the test
+    #   - the judge deep copies the expected value before comparing it, so an
+    #     expected set of courses only ever matches if the submission defines
+    #     equality and hashing on the course class, which the assignment
+    #     doesn't ask for
+    enrolled = student_dict[student_name].courses()
+    names = [name for name, course in course_dict.items() if course in enrolled]
+    statement += ' == {{{}}}'.format(', '.join(names))
+
+    print(statement)
+    print('True')


### PR DESCRIPTION
Judge mode here is `doctest` (from `chapters/20 object orientation/06 exercises/dirconfig.json`, the exercise's own `config.json` doesn't set it).

## What was wrong

`evaluation/2.in` used the repr of the returned set as the expected doctest value:

```
>>> hermione.enroll(astronomy).enroll(dark_arts).courses()
{Course(238273, 'Astronomy'), Course(746473, 'Dark Arts')}
```

Two things go wrong with that, and they compound:

1. A set has no defined iteration order, so the repr freezes one arbitrary order into the test. This is not hypothetical: re-running `preparation/generator.py` today (unchanged, same seed, reference solution) already produces a *different* element order than what is committed, so the committed expected values are only valid for the Python build that happened to generate them.

2. More importantly, the judge never actually compares against the set the `.in` file names. `FeedbackTableBlock._modifyExpectedOutputChannel` (`feedbacktable.py:1618`, and `:1700` for the expected-only path) runs `copy.deepcopy(expected)` before the comparison, so by the time `set_compare` (`content_checker.py:273`) runs, the expected set holds **freshly copied** `Course` objects. `set_compare` does `len(exp - gen) == 0 and len(gen - exp) == 0`, which needs value based `__eq__` and `__hash__` on `Course`. The assignment never asks for either. A submission that leaves them at their identity defaults is correct against the description, but fails all 20 tests in the `.enroll` tab, and the feedback shows two sets whose elements merely differ in order. That is exactly the screenshot in #330.

Note `set_compare` itself *is* order insensitive, so a submission that only hashes differently (say `hash((self.id, self.name))`) was already accepted before this PR. The failing submissions are the ones without value equality on `Course`, and their symptom presents as an order difference.

## The fix

Move the comparison into the submission, so the judge only ever compares a bool:

```
>>> hermione.enroll(astronomy).enroll(dark_arts).courses() == {astronomy, dark_arts}
True
```

The expected set is built from the course variables already bound in the context, not from new `Course(...)` calls, so it works whether or not the submission defines equality on `Course`. `True` survives the deepcopy, and Python's own `set.__eq__` is order free, so iteration order can no longer leak in.

Descriptions and both reference solutions are untouched, so the contract is unchanged. Set literals are taught in chapter 14 and `==` in chapter 6, both well before chapter 20.

Exact `set`-ness is still enforced: the `Student` tab keeps `courses()` -> `set()` as a plain expected value, and `set_compare`'s `type(exp) != type(gen)` check rejects a `frozenset` there (verified below).

`preparation/generator.py` is updated in lockstep, and also needed `import importlib.util` instead of `import importlib` to run at all on current Python.

## Verification

All from the repo root, exercise dir `chapters/20 object orientation/06 exercises/02 enrollments`.

Reference solution passes:

```sh
python3 scripts/verify_pythia_exercise.py "chapters/20 object orientation/06 exercises/02 enrollments" "chapters/20 object orientation/06 exercises/02 enrollments/solution/solution.en.py" --no-pull
```

58 passed, 0 failed, exit 0.

The regression test, a correct submission with identity based hashing on `Course` (so arbitrary set order), which was rejected 20/20 before this PR:

```sh
# strip __hash__/__eq__ from Course in solution.en.py -> /tmp/reordered330.py
python3 scripts/verify_pythia_exercise.py "chapters/20 object orientation/06 exercises/02 enrollments" /tmp/reordered330.py --no-pull
```

Before: 38 passed, 20 failed, rejected. After: 58 passed, 0 failed, accepted.

Wrong answers still rejected (all with `--expect-fail --no-pull`, all exit 0):

| submission | result |
| --- | --- |
| empty stub | 4 passed, 54 failed, runtime error |
| `enroll` overwrites (`self._courses = {course}`) | 41 passed, 17 failed, wrong answer |
| `courses()` adds a spurious `Course(111111, 'Ghost')` | 35 passed, 23 failed, wrong answer |
| `courses()` returns a `list` | 35 passed, 23 failed, wrong answer |
| `courses()` returns a `frozenset` | 55 passed, 3 failed, wrong answer |

Dutch and English solutions with the matching `natural_language`, driving the judge directly (the verify script hardcodes `en`):

```
natural_language=nl solution=solution.nl.py accepted: True | status: correct answer | tests: 40/40 passed
natural_language=en solution=solution.en.py accepted: True | status: correct answer | tests: 40/40 passed
```

Robustness, since set order varies between processes: 10 consecutive runs of the reference solution, and 10 of the identity-hash variant, all 10/10 accepted in both cases.

<details>
<summary>Generator reproduction proof</summary>

Copied `preparation/generator.py`, `preparation/ageChecker.py` and `solution/` into a throwaway dir, ran the generator there, and diffed against the committed `evaluation/`:

```sh
T=$(mktemp -d)
mkdir -p "$T/preparation"
cp "$EX/preparation/generator.py" "$EX/preparation/ageChecker.py" "$T/preparation/"
cp -R "$EX/solution" "$T/solution"
cd "$T/preparation" && PYTHONPATH="$REPO/utils" python3 generator.py
diff -r "$EX/evaluation" "$T/evaluation"
```

```
Only in .../evaluation: 0.out
diff -r .../evaluation/1.in /tmp/.../evaluation/1.in
42c42
< 39
---
> 45
52c52
< 40
---
> 46
72c72
< 40
---
> 46
Only in .../evaluation: 1.out
Only in .../evaluation: 2.out
```

So `0.in` and `2.in` reproduce byte for byte. Two pre-existing things show up and neither is touched by this PR:

- the generator does not emit `.out` files at all (those only carry the tab name, `independent examples`, and the `nl` translation block), hence the three "Only in" lines
- `1.in` bakes in today's ages (39/40/40 when it was generated, 45/46/46 today). Harmless, because the `AgeChecker` output processor recomputes the expected age at judge time and overrides the literal, which is also why the reference solution still passes. Left alone to keep this diff to the point.

</details>

<details>
<summary>How the deepcopy was confirmed</summary>

Ran the judge from a patched copy with a print in `set_compare`, against a submission without `__eq__`/`__hash__` on `Course` and an expected value written as `{astronomy}`:

```
DBG want='{astronomy}' scope_astronomy=Course(238273, 'Astronomy')/140737450873088
DBG set_compare exp={Course(238273, 'Astronomy')} <class 'set'> gen={Course(238273, 'Astronomy')} <class 'set'> expids=[140737450875920] genids=[140737450873088]
DBG diffs 1 1
```

The generated set holds the object bound in the scope, the expected set holds a copy with a different id. So naming the course variables in the expected value is not enough, the comparison has to happen inside the submission.

</details>

## Manual testing

```sh
python3 scripts/verify_pythia_exercise.py "chapters/20 object orientation/06 exercises/02 enrollments" "chapters/20 object orientation/06 exercises/02 enrollments/solution/solution.en.py" --no-pull

printf '# no implementation\n' > /tmp/stub330.py
python3 scripts/verify_pythia_exercise.py "chapters/20 object orientation/06 exercises/02 enrollments" /tmp/stub330.py --expect-fail --no-pull
```

To reproduce the original bug: take `solution/solution.en.py`, delete `__hash__` and `__eq__` from `Course`, and run it against `master`'s `2.in` (rejected, 20 failures with identical looking sets) and against this branch's (accepted).

Closes #330
