### PR TITLE
Frame pcinput as a book-only module and give the input() equivalents for Dodona

### DIFF
--- a/chapters/05 simple functions/03 modules/description/description.en.md
+++ b/chapters/05 simple functions/03 modules/description/description.en.md
@@ -132,6 +132,18 @@ print( "The same 3 numbers are:", random(), random(), random() )
 
 ### `pcinput`
 
+{:class="callout callout-info"}
+> #### Note
+> On Dodona you do not use `pcinput`. You read the input with `input()` and cast it to the type you need, as in the table below. The module exists to keep asking until the user enters something valid, and that is never needed here: the input of an exercise on Dodona comes from a fixed test case instead of from a person typing at the keyboard, so it is always valid already and there is nothing to ask again. For the same reason you do not need the extra tidying up that `getString()` and `getLetter()` do, which is why plain `input(prompt)` replaces both. The explanation that follows describes the module of the printed book. It applies only when you run the exercises in your own environment, outside Dodona, where you save `pcinput.py` next to your own code.
+
+| in the book | on Dodona |
+|-------------|-----------|
+| `getInteger(prompt)` | `int(input(prompt))` |
+| `getFloat(prompt)` | `float(input(prompt))` |
+| `getString(prompt)` | `input(prompt)` |
+| `getLetter(prompt)` | `input(prompt)` |
+{:class="table table-striped table-condensed" style="width:auto;margin-left:auto;margin-right:auto;"}
+
 `pcinput` is a module I wrote for this book. You can find it in Appendix
 31,
 and can easily recreate it (or simply download it from
@@ -193,33 +205,3 @@ for a float.
 {:class="callout callout-info"}
 > #### Note
 > I do not explain here how the functions of `pcinput` work, as they are implemented using concepts that are discussed much later in the book. You will learn, in time, how to develop such functions yourself. For now, do not worry about how they work, but just use them. This is the attitude that you should have towards most standard functions: as long as you know what they do, which parameters they need, and what they return, you do not need to spend time considering how they work.
-
-On Dodona you do not use `pcinput`. The module is not available here, so
-importing it gives an error. And you do not need it either: the whole
-point of these functions is to keep asking until the user enters
-something valid, but the input of an exercise on Dodona comes from a
-fixed test case instead of from a person typing at the keyboard, so it is
-always valid already and there is nothing to ask again. Reading the input
-with `input()` and casting it to the type you need is therefore enough:
-
-| in the book | on Dodona |
-|-------------|-----------|
-| `getInteger(prompt)` | `int(input(prompt))` |
-| `getFloat(prompt)` | `float(input(prompt))` |
-| `getString(prompt)` | `input(prompt)` |
-| `getLetter(prompt)` | `input(prompt)` |
-{:class="table table-striped table-condensed" style="width:auto;margin-left:auto;margin-right:auto;"}
-
-The example above thus becomes the following on Dodona:
-
-```python
-num1 = int( input( "Please enter an integer: " ) )
-num2 = int( input( "Please enter another integer: " ) )
-
-print( "The sum of", num1, "and", num2, "is", num1 + num2 )
-```
-
-Keep in mind that `getString()` also removes the leading and trailing
-spaces of the input, and that `getLetter()` returns a capital. If you
-need that, you write it yourself as `input(prompt).strip()` and
-`input(prompt).strip().upper()`.

--- a/chapters/05 simple functions/03 modules/description/description.en.md
+++ b/chapters/05 simple functions/03 modules/description/description.en.md
@@ -174,9 +174,9 @@ is meant to support a different language). But for the purpose of
 learning Python, they work fine.
 
 Create or download the `pcinput` module, make sure that it is located in
-the folder where you write your Python code, then create a file with the
-code below in it. Run it, try to enter something else than an integer,
-and see what happens.
+the folder where you write your Python code on your own machine, then
+create a file with the code below in it. Run it, try to enter something
+else than an integer, and see what happens.
 
 ```python
 from pcinput import getInteger
@@ -193,3 +193,33 @@ for a float.
 {:class="callout callout-info"}
 > #### Note
 > I do not explain here how the functions of `pcinput` work, as they are implemented using concepts that are discussed much later in the book. You will learn, in time, how to develop such functions yourself. For now, do not worry about how they work, but just use them. This is the attitude that you should have towards most standard functions: as long as you know what they do, which parameters they need, and what they return, you do not need to spend time considering how they work.
+
+On Dodona you do not use `pcinput`. The module is not available here, so
+importing it gives an error. And you do not need it either: the whole
+point of these functions is to keep asking until the user enters
+something valid, but the input of an exercise on Dodona comes from a
+fixed test case instead of from a person typing at the keyboard, so it is
+always valid already and there is nothing to ask again. Reading the input
+with `input()` and casting it to the type you need is therefore enough:
+
+| in the book | on Dodona |
+|-------------|-----------|
+| `getInteger(prompt)` | `int(input(prompt))` |
+| `getFloat(prompt)` | `float(input(prompt))` |
+| `getString(prompt)` | `input(prompt)` |
+| `getLetter(prompt)` | `input(prompt)` |
+{:class="table table-striped table-condensed" style="width:auto;margin-left:auto;margin-right:auto;"}
+
+The example above thus becomes the following on Dodona:
+
+```python
+num1 = int( input( "Please enter an integer: " ) )
+num2 = int( input( "Please enter another integer: " ) )
+
+print( "The sum of", num1, "and", num2, "is", num1 + num2 )
+```
+
+Keep in mind that `getString()` also removes the leading and trailing
+spaces of the input, and that `getLetter()` returns a capital. If you
+need that, you write it yourself as `input(prompt).strip()` and
+`input(prompt).strip().upper()`.

--- a/chapters/05 simple functions/03 modules/description/description.nl.md
+++ b/chapters/05 simple functions/03 modules/description/description.nl.md
@@ -186,9 +186,9 @@ schrijft (daar heb ik een andere versie van de module voor), maar om
 Python te leren zijn deze functies afdoende.
 
 Creëer of download de `pcinput` module, zorg dat hij staat in de folder
-waar je je programma's schrijft, en maak dan een Python programma met
-onderstaande code. Voer het programma uit en test het door iets in te
-geven wat geen integer is.
+waar je op je eigen computer je programma's schrijft, en maak dan een
+Python programma met onderstaande code. Voer het programma uit en test
+het door iets in te geven wat geen integer is.
 
 ```python
 from pcinput import getInteger
@@ -205,3 +205,34 @@ prompt om de gebruiker te vragen een float in te geven.
 {:class="callout callout-info"}
 > #### Opmerking
 > Ik leg niet uit hoe `pcinput` werkt, omdat ik er concepten voor gebruik die pas in hoofdstuk 18 aan bod komen. Je zult later leren hoe je zelf dit soort functies kunt maken. Je hoeft je vooralsnog niet druk te maken over hoe ze werken, je hoeft ze alleen maar te gebruiken. Dat is de houding die je tegenover de meeste standaardfuncties moet hebben: zolang je maar weet wat ze doen, welke parameters ze nodig hebben, en wat ze retourneren, heeft het geen zin na te denken over hoe ze werken.
+
+Op Dodona gebruik je `pcinput` niet. De module is hier niet beschikbaar,
+dus een import van de module geeft een foutmelding. Je hebt hem ook niet
+nodig: de hele bedoeling van deze functies is om te blijven vragen tot de
+gebruiker iets correct ingeeft, maar de input van een oefening op Dodona
+komt uit een vast testgeval en wordt niet door een persoon ingetypt. De
+input is dus altijd al correct en er is niets om opnieuw te vragen. Het
+volstaat daarom om de input met `input()` te lezen en te casten naar het
+type dat je nodig hebt:
+
+| in het boek | op Dodona |
+|-------------|-----------|
+| `getInteger(prompt)` | `int(input(prompt))` |
+| `getFloat(prompt)` | `float(input(prompt))` |
+| `getString(prompt)` | `input(prompt)` |
+| `getLetter(prompt)` | `input(prompt)` |
+{:class="table table-striped table-condensed" style="width:auto;margin-left:auto;margin-right:auto;"}
+
+Het voorbeeld hierboven wordt op Dodona dus:
+
+```python
+num1 = int( input( "Geef een geheel getal: " ) )
+num2 = int( input( "Geef een ander geheel getal: " ) )
+
+print( num1, "+", num2, "=", num1 + num2 )
+```
+
+Houd er wel rekening mee dat `getString()` ook de spaties voor en na de
+input weghaalt, en dat `getLetter()` een hoofdletter retourneert. Heb je
+dat nodig, dan schrijf je dat zelf als `input(prompt).strip()` en
+`input(prompt).strip().upper()`.

--- a/chapters/05 simple functions/03 modules/description/description.nl.md
+++ b/chapters/05 simple functions/03 modules/description/description.nl.md
@@ -141,6 +141,18 @@ print( "Dezelfde 3 zijn:", random(), random(), random() )
 
 ### `pcinput`
 
+{:class="callout callout-info"}
+> #### Opmerking
+> Op Dodona gebruik je `pcinput` niet. Je leest de input met `input()` en cast die naar het type dat je nodig hebt, zoals in de tabel hieronder. De module bestaat om te blijven vragen tot de gebruiker iets correct ingeeft, en dat is hier nooit nodig: de input van een oefening op Dodona komt uit een vast testgeval en wordt niet door een persoon ingetypt, dus die is altijd al correct en er is niets om opnieuw te vragen. Om dezelfde reden heb je het extra opschoonwerk dat `getString()` en `getLetter()` doen niet nodig, en volstaat `input(prompt)` voor beide. De uitleg die volgt beschrijft de module uit het gedrukte boek. Die geldt alleen als je de oefeningen in je eigen omgeving uitvoert, buiten Dodona, met `pcinput.py` naast je eigen code.
+
+| in het boek | op Dodona |
+|-------------|-----------|
+| `getInteger(prompt)` | `int(input(prompt))` |
+| `getFloat(prompt)` | `float(input(prompt))` |
+| `getString(prompt)` | `input(prompt)` |
+| `getLetter(prompt)` | `input(prompt)` |
+{:class="table table-striped table-condensed" style="width:auto;margin-left:auto;margin-right:auto;"}
+
 `pcinput` is een module die ik voor dit boek geschreven heb. Je vindt
 hem in appendix
 31,
@@ -205,34 +217,3 @@ prompt om de gebruiker te vragen een float in te geven.
 {:class="callout callout-info"}
 > #### Opmerking
 > Ik leg niet uit hoe `pcinput` werkt, omdat ik er concepten voor gebruik die pas in hoofdstuk 18 aan bod komen. Je zult later leren hoe je zelf dit soort functies kunt maken. Je hoeft je vooralsnog niet druk te maken over hoe ze werken, je hoeft ze alleen maar te gebruiken. Dat is de houding die je tegenover de meeste standaardfuncties moet hebben: zolang je maar weet wat ze doen, welke parameters ze nodig hebben, en wat ze retourneren, heeft het geen zin na te denken over hoe ze werken.
-
-Op Dodona gebruik je `pcinput` niet. De module is hier niet beschikbaar,
-dus een import van de module geeft een foutmelding. Je hebt hem ook niet
-nodig: de hele bedoeling van deze functies is om te blijven vragen tot de
-gebruiker iets correct ingeeft, maar de input van een oefening op Dodona
-komt uit een vast testgeval en wordt niet door een persoon ingetypt. De
-input is dus altijd al correct en er is niets om opnieuw te vragen. Het
-volstaat daarom om de input met `input()` te lezen en te casten naar het
-type dat je nodig hebt:
-
-| in het boek | op Dodona |
-|-------------|-----------|
-| `getInteger(prompt)` | `int(input(prompt))` |
-| `getFloat(prompt)` | `float(input(prompt))` |
-| `getString(prompt)` | `input(prompt)` |
-| `getLetter(prompt)` | `input(prompt)` |
-{:class="table table-striped table-condensed" style="width:auto;margin-left:auto;margin-right:auto;"}
-
-Het voorbeeld hierboven wordt op Dodona dus:
-
-```python
-num1 = int( input( "Geef een geheel getal: " ) )
-num2 = int( input( "Geef een ander geheel getal: " ) )
-
-print( num1, "+", num2, "=", num1 + num2 )
-```
-
-Houd er wel rekening mee dat `getString()` ook de spaties voor en na de
-input weghaalt, en dat `getLetter()` een hoofdletter retourneert. Heb je
-dat nodig, dan schrijf je dat zelf als `input(prompt).strip()` en
-`input(prompt).strip().upper()`.

--- a/chapters/05 simple functions/04 what you learned/description/description.en.md
+++ b/chapters/05 simple functions/04 what you learned/description/description.en.md
@@ -28,5 +28,6 @@ In this chapter, you learned about:
 -   The `random` module functions `random()`, `randint()`, and `seed()`
 
 -   The `pcinput` module functions `getInteger()`, `getFloat()`,
-    `getString()`, and `getLetter()`
+    `getString()`, and `getLetter()` from the book, and their `input()`
+    equivalents on Dodona
 

--- a/chapters/05 simple functions/04 what you learned/description/description.nl.md
+++ b/chapters/05 simple functions/04 what you learned/description/description.nl.md
@@ -28,4 +28,5 @@ In dit hoofdstuk is het volgende besproken:
 -   De `random` functies `random()`, `randint()`, en `seed()`
 
 -   De `pcinput` functies `getInteger()`, `getFloat()`, `getString()`,
-    en `getLetter()`
+    en `getLetter()` uit het boek, en hun `input()` equivalenten op
+    Dodona

--- a/chapters/06 conditions/02 conditional statements/description/description.en.md
+++ b/chapters/06 conditions/02 conditional statements/description/description.en.md
@@ -163,8 +163,8 @@ block directly under the `else` will be executed.
 You can test whether an integer is odd or even using the modulo
 operator. Specifically, when `x % 2` equals zero, then `x` is even, else
 it is odd. Write some code that asks for an integer and then reports
-whether it is even or odd (you can use the `getInteger()` function from
-`pcinput` to ask for an integer).
+whether it is even or odd (you can use `int( input() )` to ask for an
+integer).
 
 Note: As far as indentation is concerned, it is not absolutely necessary
 to have the code block under the `else` branch use the same number of

--- a/chapters/06 conditions/02 conditional statements/description/description.nl.md
+++ b/chapters/06 conditions/02 conditional statements/description/description.nl.md
@@ -165,8 +165,8 @@ uitgevoerd.
 Je kunt testen of een integer even of oneven is met de modulo operator.
 Namelijk als `x % 2` nul is, dan is `x` even, en anders is `x` oneven.
 Schrijf code die vraagt om een integer en dan rapporteert of de integer
-even of oneven is (je kunt de `getInteger()` functie van `pcinput`
-gebruiken om om een integer te vragen).
+even of oneven is (je kunt `int( input() )` gebruiken om om een integer
+te vragen).
 
 Opmerking met betrekking tot inspringing: het is niet absoluut
 noodzakelijk om het blok code onder de `else` aan te lijnen met het blok

--- a/chapters/06 conditions/03 early exits/description/description.en.md
+++ b/chapters/06 conditions/03 early exits/description/description.en.md
@@ -5,9 +5,7 @@ a value that cannot be processed, the program should just end. You could
 code that as follows:
 
 ```python
-from pcinput import getInteger
-
-num = getInteger( "Please enter a positive integer: " )
+num = int( input( "Please enter a positive integer: " ) )
 if num < 0:
     print( "You should have entered a positive integer!" )
 else:
@@ -24,10 +22,9 @@ You can do that using a special function `exit()` that is found in the
 module `sys`. The code above becomes:
 
 ```python
-from pcinput import getInteger
 from sys import exit
 
-num = getInteger( "Please enter a positive integer: " )
+num = int( input( "Please enter a positive integer: " ) )
 if num < 0:
     print( "You should have entered a positive integer!" )
     exit()

--- a/chapters/06 conditions/03 early exits/description/description.nl.md
+++ b/chapters/06 conditions/03 early exits/description/description.nl.md
@@ -5,9 +5,7 @@ een waarde invoert die niet in de berekeningen gebruikt kan worden, wil
 je het programma meteen beëindigen. Dat kun je als volgt coderen:
 
 ```python
-from pcinput import getInteger
-
-num = getInteger( "Geef een positief geheel getal: " )
+num = int( input( "Geef een positief geheel getal: " ) )
 if num < 0:
     print( "Je had een positief geheel getal moeten geven!" )
 else:
@@ -24,10 +22,9 @@ behulp van de functie `exit()` die in de module `sys` staat. De code is
 dan:
 
 ```python
-from pcinput import getInteger
 from sys import exit
 
-num = getInteger( "Geef een positief geheel getal: " )
+num = int( input( "Geef een positief geheel getal: " ) )
 if num < 0:
     print( "Je had een positief geheel getal moeten geven!" )
     exit()

--- a/chapters/07 iterations/01 while loop/description/description.en.md
+++ b/chapters/07 iterations/01 while loop/description/description.en.md
@@ -3,13 +3,11 @@ show the total. With the material from the previous chapters, you would
 program that as follows:
 
 ```python
-from pcinput import getInteger
-
-num1 = getInteger( "Number 1: " )
-num2 = getInteger( "Number 2: " )
-num3 = getInteger( "Number 3: " )
-num4 = getInteger( "Number 4: " )
-num5 = getInteger( "Number 5: " )
+num1 = int( input( "Number 1: " ) )
+num2 = int( input( "Number 2: " ) )
+num3 = int( input( "Number 3: " ) )
+num4 = int( input( "Number 4: " ) )
+num5 = int( input( "Number 5: " ) )
 
 print( "Total is", num1 + num2 + num3 + num4 + num5 )
 ```
@@ -111,12 +109,10 @@ ask the user for five numbers and print the total. This is implemented
 as follows:
 
 ```python
-from pcinput import getInteger
-
 total = 0
 count = 0
 while count < 5:
-    total += getInteger( "Please give a number: " )
+    total += int( input( "Please give a number: " ) )
     count += 1
 
 print( "Total is", total )
@@ -173,12 +169,10 @@ to enter numbers as long as he wants, until he enters a zero. Once a
 zero is entered, the total is printed, and the program ends.
 
 ```python
-from pcinput import getInteger
-    
 num = -1
 total = 0
 while num != 0:
-    num = getInteger( "Enter a number: " )
+    num = int( input( "Enter a number: " ) )
     total += num
 print( "Total is", total )
 ```
@@ -196,20 +190,18 @@ Because of these ugly elements, some programmers prefer to write this
 code as follows:
 
 ```python
-from pcinput import getInteger
-    
-num = getInteger( "Enter a number: " )
+num = int( input( "Enter a number: " ) )
 total = 0
 while num != 0:
     total += num
-    num = getInteger( "Enter a number: " )
+    num = int( input( "Enter a number: " ) )
 print( "Total is", total )
 ```
 
 This solves the ugly parts from the previous code, but introduces
-something new that is ugly, namely the repetition of the `getInteger()`
-function. How this can be solved follows at the end of this chapter. For
-now, make sure that you understand how `while` loops work.
+something new that is ugly, namely the repetition of the line that asks
+for a number. How this can be solved follows at the end of this chapter.
+For now, make sure that you understand how `while` loops work.
 
 Create a loop that lets the user enter some numbers until he enters
 zero, and then prints their total and their average. Make sure you test

--- a/chapters/07 iterations/01 while loop/description/description.nl.md
+++ b/chapters/07 iterations/01 while loop/description/description.nl.md
@@ -3,13 +3,11 @@ en dan het totaal moet laten zien. Met het materiaal dat tot nu toe
 behandeld is, zou je dat als volgt coderen:
 
 ```python
-from pcinput import getInteger
-
-num1 = getInteger( "Nummer 1: " )
-num2 = getInteger( "Nummer 2: " )
-num3 = getInteger( "Nummer 3: " )
-num4 = getInteger( "Nummer 4: " )
-num5 = getInteger( "Nummer 5: " )
+num1 = int( input( "Nummer 1: " ) )
+num2 = int( input( "Nummer 2: " ) )
+num3 = int( input( "Nummer 3: " ) )
+num4 = int( input( "Nummer 4: " ) )
+num5 = int( input( "Nummer 5: " ) )
 
 print( "Totaal is", num1 + num2 + num3 + num4 + num5 )
 ```
@@ -113,12 +111,10 @@ je de gebruiker kunt vragen om vijf getallen, en dan de som van de vijf
 te berekenen:
 
 ```python
-from pcinput import getInteger
-
 totaal = 0
 teller = 0
 while teller < 5:
-    totaal += getInteger( "Geef een nummer: " )
+    totaal += int( input( "Geef een nummer: " ) )
     teller += 1
 
 print( "Totaal is", totaal )
@@ -179,12 +175,10 @@ met het ingeven van getallen door een nul in te geven. Het totaal wordt
 afgedrukt wanneer de loop beëindigd is.
 
 ```python
-from pcinput import getInteger
-    
 num = -1
 totaal = 0
 while num != 0:
-    num = getInteger( "Geef een nummer: " )
+    num = int( input( "Geef een nummer: " ) )
     totaal += num
 print( "Totaal is", totaal )
 ```
@@ -203,20 +197,18 @@ Vanwege deze lelijke kanten aan de code, prefereren sommige programmeurs
 om het als volgt te schrijven:
 
 ```python
-from pcinput import getInteger
-    
-num = getInteger( "Geef een nummer: " )
+num = int( input( "Geef een nummer: " ) )
 totaal = 0
 while num != 0:
     totaal += num
-    num = getInteger( "Geef een nummer: " )
+    num = int( input( "Geef een nummer: " ) )
 print( "Totaal is", totaal )
 ```
 
 Dit lost de twee hierboven genoemde lelijke zaken op, maar introduceert
-iets anders lelijks, namelijk de herhaling van de `getInteger()`
-functie. Hoe je dat kunt oplossen volgt later in dit hoofdstuk. Op dit
-moment hoef je alleen te snappen hoe de `while` loop werkt.
+iets anders lelijks, namelijk de herhaling van de regel die om een
+getal vraagt. Hoe je dat kunt oplossen volgt later in dit hoofdstuk. Op
+dit moment hoef je alleen te snappen hoe de `while` loop werkt.
 
 Maak een loop die de gebruiker een aantal getallen laat ingeven, totdat
 hij nul ingeeft, en dan het totaal en het gemiddelde afdrukt. Vergeet

--- a/chapters/07 iterations/05 the loop-and-a-half/description/description.en.md
+++ b/chapters/07 iterations/05 the loop-and-a-half/description/description.en.md
@@ -8,14 +8,12 @@ zero, but that is not an error; you just want to allow the user to enter
 new numbers. How do you program that? Here is a first attempt:
 
 ```python
-from pcinput import getInteger
-
 x = 3
 y = 7
 
 while (x != 0) and (y != 0) and (x%y != 0) and (y%x != 0):
-    x = getInteger( "Enter number 1: " )
-    y = getInteger( "Enter number 2: " )
+    x = int( input( "Enter number 1: " ) )
+    y = int( input( "Enter number 2: " ) )
     if (x > 1000) or (y > 1000) or (x < 0) or (y < 0):
         print( "Numbers should both be between 0 and 1000" )
         continue
@@ -67,20 +65,18 @@ have a `continue` in the loop, you also have to copy it there. The code
 becomes something like this:
 
 ```python
-from pcinput import getInteger
-
-x = getInteger( "Enter number 1: " )
-y = getInteger( "Enter number 2: " )
+x = int( input( "Enter number 1: " ) )
+y = int( input( "Enter number 2: " ) )
 
 while (x != 0) and (y != 0) and (x%y != 0) and (y%x != 0):
     if (x > 1000) or (y > 1000) or (x < 0) or (y < 0):
         print( "Numbers should both be between 0 and 1000" )
-        x = getInteger( "Enter number 1: " )
-        y = getInteger( "Enter number 2: " )
+        x = int( input( "Enter number 1: " ) )
+        y = int( input( "Enter number 2: " ) )
         continue
     print( "Multiplication of", x, "and", y, "gives", x * y )
-    x = getInteger( "Enter number 1: " )
-    y = getInteger( "Enter number 2: " )
+    x = int( input( "Enter number 1: " ) )
+    y = int( input( "Enter number 2: " ) )
 
 if x == 0 or y == 0:
     print( "Goodbye!" )
@@ -112,14 +108,13 @@ test that decides whether or not you have to do the loop again, always
 results in `True`).
 
 ```python
-from pcinput import getInteger
 from sys import exit
 
 while True:
-    x = getInteger( "Enter number 1: " )
+    x = int( input( "Enter number 1: " ) )
     if x == 0:
         break
-    y = getInteger( "Enter number 2: " )
+    y = int( input( "Enter number 2: " ) )
     if y == 0:
         break
     if (x < 0 or x > 1000) or (y < 0 or y > 1000):
@@ -153,8 +148,8 @@ A loop like this one, that uses `while True`, is sometimes called a
 "loop-and-a-half." It is a common approach to writing loops for which
 you cannot predict when they will end.
 
-The user must enter a positive integer. You use the `getInteger()`
-function from `pcinput` for that. This function also allows entering
+The user must enter a positive integer. You read that input with
+`input()` and convert it with `int()`. That also allows entering
 negative numbers. If the user enters a negative number, you want to
 print a message and ask him again, until he entered a positive number.
 Once a positive number is entered, you print that number and the program

--- a/chapters/07 iterations/05 the loop-and-a-half/description/description.nl.md
+++ b/chapters/07 iterations/05 the loop-and-a-half/description/description.nl.md
@@ -11,14 +11,12 @@ gewoon dat de gebruiker dan een nieuw getal ingeeft. Hoe programmeer je
 zoiets? Hier is een eerste poging:
 
 ```python
-from pcinput import getInteger
-
 x = 3
 y = 7
 
 while (x != 0) and (y != 0) and (x%y != 0) and (y%x != 0):
-    x = getInteger( "Geef nummer 1: " )
-    y = getInteger( "Geef nummer 2: " )
+    x = int( input( "Geef nummer 1: " ) )
+    y = int( input( "Geef nummer 2: " ) )
     if (x > 1000) or (y > 1000) or (x < 0) or (y < 0):
         print( "Nummers moeten tussen 0 en 1000 zijn" )
         continue
@@ -71,20 +69,18 @@ voor die continue ook om de inputs vragen, anders krijg je een eindeloze
 loop. De code wordt dan iets als:
 
 ```python
-from pcinput import getInteger
-
-x = getInteger( "Geef nummer 1: " )
-y = getInteger( "Geef nummer 2: " )
+x = int( input( "Geef nummer 1: " ) )
+y = int( input( "Geef nummer 2: " ) )
 
 while (x != 0) and (y != 0) and (x%y != 0) and (y%x != 0):
     if (x > 1000) or (y > 1000) or (x < 0) or (y < 0):
         print( "Nummers moeten tussen 0 en 1000 zijn" )
-        x = getInteger( "Geef nummer 1: " )
-        y = getInteger( "Geef nummer 2: " )
+        x = int( input( "Geef nummer 1: " ) )
+        y = int( input( "Geef nummer 2: " ) )
         continue
     print( x, "keer", y, "is", x * y )
-    x = getInteger( "Geef nummer 1: " )
-    y = getInteger( "Geef nummer 2: " )
+    x = int( input( "Geef nummer 1: " ) )
+    y = int( input( "Geef nummer 2: " ) )
 
 if x == 0 or y == 0:
     print( "Klaar!" )
@@ -118,14 +114,13 @@ kun je `while True` gebruiken (dit betekent: de test die je uitvoert om
 te besluiten of de loop uitgevoerd moet worden, geeft altijd `True`).
 
 ```python
-from pcinput import getInteger
 from sys import exit
 
 while True:
-    x = getInteger( "Geef nummer 1: " )
+    x = int( input( "Geef nummer 1: " ) )
     if x == 0:
         break
-    y = getInteger( "Geef nummer 2: " )
+    y = int( input( "Geef nummer 2: " ) )
     if y == 0:
         break
     if (x < 0 or x > 1000) or (y < 0 or y > 1000):
@@ -160,9 +155,9 @@ Een loop als deze, die `while True` gebruikt, wordt soms een
 het schrijven van een loop waarbij je niet precies weet wanneer de loop
 moet eindigen.
 
-De gebruiker geeft een positief geheel getal. Je gebruikt daarvoor de
-`getInteger()` functie van `pcinput`. Deze functie staat het echter ook
-toe om negatieve getallen in te geven. Als de gebruiker een negatief
+De gebruiker geeft een positief geheel getal. Je leest die input in met
+`input()` en zet ze om met `int()`. Dat laat echter ook toe
+om negatieve getallen in te geven. Als de gebruiker een negatief
 getal ingeeft, wil je melden dat dat niet mag, en hem opnieuw een getal
 laten ingeven. Dit blijf je doen totdat daadwerkelijk een positief getal
 is ingegeven. Zodra een positief getal is ingegeven, druk je dat af en

--- a/chapters/08 functions/02 definition/description/description.en.md
+++ b/chapters/08 functions/02 definition/description/description.en.md
@@ -269,15 +269,14 @@ the spirit of the program as a whole. For instance:
 
 ```python
 from math import sqrt
-from pcinput import getInteger
 
 def pythagoras( a, b ):
     if a <= 0 or b <= 0:
         return -1
     return sqrt( a*a + b*b )
 
-num1 = getInteger( "Give side 1: " )
-num2 = getInteger( "Give side 2: " )
+num1 = int( input( "Give side 1: " ) )
+num2 = int( input( "Give side 2: " ) )
 num3 = pythagoras( num1, num2 )
 if num3 < 0:
     print( "The numbers you provided cannot be used." )

--- a/chapters/08 functions/02 definition/description/description.nl.md
+++ b/chapters/08 functions/02 definition/description/description.nl.md
@@ -285,15 +285,14 @@ omstandigheden naar wens afhandelen. Bijvoorbeeld:
 
 ```python
 from math import sqrt
-from pcinput import getInteger
 
 def pythagoras( a, b ):
     if a <= 0 or b <= 0:
         return -1
     return sqrt( a*a + b*b )
 
-num1 = getInteger( "Geef zijde 1: " )
-num2 = getInteger( "Geef zijde 2: " )
+num1 = int( input( "Geef zijde 1: " ) )
+num2 = int( input( "Geef zijde 2: " ) )
 num3 = pythagoras( num1, num2 )
 if num3 < 0:
     print( "De getallen kunnen niet worden gebruikt." )

--- a/chapters/08 functions/08 exercises/05 loop-and-a-half/description/description.en.md
+++ b/chapters/08 functions/08 exercises/05 loop-and-a-half/description/description.en.md
@@ -11,14 +11,13 @@ get rid of the `exit()` and thus the possible ugly output by introducing
 a `main()` function.
 
 ```python
-from pcinput import getInteger
 from sys import exit
 
 while True:
-    x = getInteger( "Enter number 1: " )
+    x = int( input( "Enter number 1: " ) )
     if x == 0:
         break
-    y = getInteger( "Enter number 2: " )
+    y = int( input( "Enter number 2: " ) )
     if y == 0:
         break
     if (x < 0 or x > 1000) or (y < 0 or y > 1000):
@@ -35,10 +34,10 @@ print( "Goodbye!" )
 ### Assignment
 
 Write a function `get_valid_number` that takes a prompt (`str`). The function
-must use `getInteger` to keep asking for an integer using the given prompt,
-until the user enters a value between 0 and 1000 (inclusive); for every value
-outside that range, print `The numbers should be between 0 and 1000` before
-asking again. The function must return the validated integer (`int`).
+must keep asking for an integer using the given prompt, until the user enters
+a value between 0 and 1000 (inclusive); for every value outside that range,
+print `The numbers should be between 0 and 1000` before asking again. The
+function must return the validated integer (`int`).
 
 Rewrite the code above into a function `main` that takes no arguments, using
 `get_valid_number` to fix the issue described above. Also get rid of the

--- a/chapters/08 functions/08 exercises/05 loop-and-a-half/description/description.nl.md
+++ b/chapters/08 functions/08 exercises/05 loop-and-a-half/description/description.nl.md
@@ -8,18 +8,17 @@ moeten krijgen. Ik gaf ook aan dat he dat het gemakkelijkste kon
 oplossen via functies. Creëer een functie die je aan onderstaande code
 toevoegt en in onderstaande code aanroept, zodat het probleem wordt
 opgelost. Verwijder ook de `exit()` door introductie van een `main()`
-functie. Hint: Maak een variant van `getInteger()` die garandeert dat de
-integer tussen 0 en 1000 ligt.
+functie. Hint: Maak een functie die de input inleest en garandeert dat
+het gehele getal tussen 0 en 1000 ligt.
 
 ```python
-from pcinput import getInteger
 from sys import exit
 
 while True:
-    x = getInteger( "Geef nummer 1: " )
+    x = int( input( "Geef nummer 1: " ) )
     if x == 0:
         break
-    y = getInteger( "Geef nummer 2: " )
+    y = int( input( "Geef nummer 2: " ) )
     if y == 0:
         break
     if (x < 0 or x > 1000) or (y < 0 or y > 1000):
@@ -36,9 +35,9 @@ print( "Tot ziens!" )
 ### Opgave
 
 Schrijf een functie `vraag_geldig_getal` waaraan een prompt (`str`) moet
-doorgegeven worden. De functie moet via `getInteger` blijven vragen om een
-geheel getal met de gegeven prompt, tot de gebruiker een waarde tussen 0 en
-1000 (inclusief) invoert; voor elke waarde buiten dat bereik print je
+doorgegeven worden. De functie moet blijven vragen om een geheel getal met de
+gegeven prompt, tot de gebruiker een waarde tussen 0 en 1000 (inclusief)
+invoert; voor elke waarde buiten dat bereik print je
 `De nummers moeten tussen 0 en 1000 liggen` voor je opnieuw vraagt. De functie
 moet het gevalideerde getal (`int`) teruggeven.
 

--- a/chapters/17 exceptions/01 errors and exceptions/description/description.en.md
+++ b/chapters/17 exceptions/01 errors and exceptions/description/description.en.md
@@ -13,9 +13,7 @@ code. For instance, the following program causes a runtime error when
 you enter a zero as input:
 
 ```python
-from pcinput import getInteger
-
-num = getInteger( "Please enter a number: " )
+num = int( input( "Please enter a number: " ) )
 print( "3 divided by {} is {}".format( num, 3/num ) )
 print( "Goodbye!" )
 ```
@@ -24,9 +22,7 @@ Python tells you what kind of error it is, namely a `ZeroDivisionError`.
 To fix it, you can change the program:
 
 ```python
-from pcinput import getInteger
-
-num = getInteger( "Please enter a number: " )
+num = int( input( "Please enter a number: " ) )
 if num == 0:
     print( "Dividing by zero is not allowed" )
 else:

--- a/chapters/17 exceptions/01 errors and exceptions/description/description.nl.md
+++ b/chapters/17 exceptions/01 errors and exceptions/description/description.nl.md
@@ -13,9 +13,7 @@ code uit te breiden of te wijzigen. Bijvoorbeeld, het volgende programma
 geeft een runtime error als je nul ingeeft:
 
 ```python
-from pcinput import getInteger
-
-num = getInteger( "Geef een getal: " )
+num = int( input( "Geef een getal: " ) )
 print( "3 gedeeld door {} is {}".format( num, 3/num ) )
 print( "Tot ziens!" )
 ```
@@ -24,9 +22,7 @@ Python vertelt je wat voor soort error het is, namelijk een
 `ZeroDivisionError`. Om die op te lossen, kun je het programma wijzigen:
 
 ```python
-from pcinput import getInteger
-
-num = getInteger( "Geef een getal: " )
+num = int( input( "Geef een getal: " ) )
 if num == 0:
     print( "Je kunt niet delen door nul" )
 else:

--- a/chapters/17 exceptions/02 exception handling/description/description.en.md
+++ b/chapters/17 exceptions/02 exception handling/description/description.en.md
@@ -26,9 +26,7 @@ Using exception handling, the code at the start of this chapter can be
 written as follows to avoid runtime errors:
 
 ```python
-from pcinput import getInteger
-
-num = getInteger( "Please enter a number: " )
+num = int( input( "Please enter a number: " ) )
 try:
     print( "3 divided by {} is {}".format( num, 3/num ) )
 except:
@@ -42,9 +40,7 @@ zero and when a user enters 3. Both exceptions are handled by the same
 `try … except` clause.
 
 ```python
-from pcinput import getInteger
-
-num = getInteger( "Please enter a number: " )
+num = int( input( "Please enter a number: " ) )
 try:
     print( "3 divided by {} is {}".format( num, 3/num ) )
     print( "3 divided by {}-3 is {}".format( num, 3/(num-3) ) )

--- a/chapters/17 exceptions/02 exception handling/description/description.nl.md
+++ b/chapters/17 exceptions/02 exception handling/description/description.nl.md
@@ -26,9 +26,7 @@ dit hoofdstuk als volgt geschreven worden om runtime errors te
 vermijden:
 
 ```python
-from pcinput import getInteger
-
-num = getInteger( "Geef een getal: " )
+num = int( input( "Geef een getal: " ) )
 try:
     print( "3 gedeeld door {} is {}".format( num, 3/num ) )
 except:
@@ -43,9 +41,7 @@ uitzonderingen worden via dezelfde `try … except` constructie
 afgehandeld.
 
 ```python
-from pcinput import getInteger
-
-num = getInteger( "Geen een getal: " )
+num = int( input( "Geen een getal: " ) )
 try:
     print( "3 gedeeld door {} is {}".format( num, 3/num ) )
     print( "3 gedeeld door {}-3 is {}".format( num, 3/(num-3) ) )

--- a/chapters/17 exceptions/02 exception handling/description/description.nl.md
+++ b/chapters/17 exceptions/02 exception handling/description/description.nl.md
@@ -41,7 +41,7 @@ uitzonderingen worden via dezelfde `try … except` constructie
 afgehandeld.
 
 ```python
-num = int( input( "Geen een getal: " ) )
+num = int( input( "Geef een getal: " ) )
 try:
     print( "3 gedeeld door {} is {}".format( num, 3/num ) )
     print( "3 gedeeld door {}-3 is {}".format( num, 3/(num-3) ) )

--- a/chapters/28 appendices/03 pcinput.py/description/description.en.md
+++ b/chapters/28 appendices/03 pcinput.py/description/description.en.md
@@ -1,3 +1,7 @@
+{:class="callout callout-info"}
+> #### Note
+> This appendix documents the `pcinput` module from the printed book, as reference material. The module is not available on Dodona, so you cannot import it in a solution that you submit. On Dodona you read the input with `input()` and cast it to the type you need: `int(input(prompt))` instead of `getInteger(prompt)`, `float(input(prompt))` instead of `getFloat(prompt)`, and `input(prompt)` instead of `getString(prompt)` or `getLetter(prompt)`. The functions below keep asking until the user enters something valid, and that is not needed on Dodona, where the input of an exercise comes from a fixed test case and is thus always valid already.
+
 In many of the exercises in this book, it is useful to have a function
 available that accepts inputs of a certain type. I created a module
 called `pcinput` which contains a number of such functions. During many

--- a/chapters/28 appendices/03 pcinput.py/description/description.en.md
+++ b/chapters/28 appendices/03 pcinput.py/description/description.en.md
@@ -1,6 +1,6 @@
 {:class="callout callout-info"}
 > #### Note
-> This appendix documents the `pcinput` module from the printed book, as reference material. The module is not available on Dodona, so you cannot import it in a solution that you submit. On Dodona you read the input with `input()` and cast it to the type you need: `int(input(prompt))` instead of `getInteger(prompt)`, `float(input(prompt))` instead of `getFloat(prompt)`, and `input(prompt)` instead of `getString(prompt)` or `getLetter(prompt)`. The functions below keep asking until the user enters something valid, and that is not needed on Dodona, where the input of an exercise comes from a fixed test case and is thus always valid already.
+> This appendix documents the `pcinput` module from the printed book, as reference material for readers who run the exercises in their own environment, outside Dodona. The module is not available on Dodona, so you cannot import it in a solution that you submit. On Dodona you read the input with `input()` and cast it to the type you need: `int(input(prompt))` instead of `getInteger(prompt)`, `float(input(prompt))` instead of `getFloat(prompt)`, and `input(prompt)` instead of `getString(prompt)` or `getLetter(prompt)`. The functions below keep asking until the user enters something valid, and that is not needed on Dodona, where the input of an exercise comes from a fixed test case and is thus always valid already.
 
 In many of the exercises in this book, it is useful to have a function
 available that accepts inputs of a certain type. I created a module

--- a/chapters/28 appendices/03 pcinput.py/description/description.nl.md
+++ b/chapters/28 appendices/03 pcinput.py/description/description.nl.md
@@ -1,3 +1,7 @@
+{:class="callout callout-info"}
+> #### Opmerking
+> Deze appendix documenteert de `pcinput` module uit het boek, als naslagwerk. De module is niet beschikbaar op Dodona, dus je kunt hem niet importeren in een oplossing die je indient. Op Dodona lees je de input met `input()` en cast je die naar het type dat je nodig hebt: `int(input(prompt))` in plaats van `getInteger(prompt)`, `float(input(prompt))` in plaats van `getFloat(prompt)`, en `input(prompt)` in plaats van `getString(prompt)` of `getLetter(prompt)`. De functies hieronder blijven vragen tot de gebruiker iets correct ingeeft, en dat is op Dodona niet nodig: de input van een oefening komt uit een vast testgeval en is dus altijd al correct.
+
 In veel opgaves in dit boek is het nuttig om een functie te hebben die
 gebruiker een input laat geven die voldoet aan specifieke eisen. Ik heb
 een module gecreëerd, `pcinput` geheten, die een aantal van die functies

--- a/chapters/28 appendices/03 pcinput.py/description/description.nl.md
+++ b/chapters/28 appendices/03 pcinput.py/description/description.nl.md
@@ -1,6 +1,6 @@
 {:class="callout callout-info"}
 > #### Opmerking
-> Deze appendix documenteert de `pcinput` module uit het boek, als naslagwerk. De module is niet beschikbaar op Dodona, dus je kunt hem niet importeren in een oplossing die je indient. Op Dodona lees je de input met `input()` en cast je die naar het type dat je nodig hebt: `int(input(prompt))` in plaats van `getInteger(prompt)`, `float(input(prompt))` in plaats van `getFloat(prompt)`, en `input(prompt)` in plaats van `getString(prompt)` of `getLetter(prompt)`. De functies hieronder blijven vragen tot de gebruiker iets correct ingeeft, en dat is op Dodona niet nodig: de input van een oefening komt uit een vast testgeval en is dus altijd al correct.
+> Deze appendix documenteert de `pcinput` module uit het boek, als naslagwerk voor wie de oefeningen in een eigen omgeving uitvoert, buiten Dodona. De module is niet beschikbaar op Dodona, dus je kunt hem niet importeren in een oplossing die je indient. Op Dodona lees je de input met `input()` en cast je die naar het type dat je nodig hebt: `int(input(prompt))` in plaats van `getInteger(prompt)`, `float(input(prompt))` in plaats van `getFloat(prompt)`, en `input(prompt)` in plaats van `getString(prompt)` of `getLetter(prompt)`. De functies hieronder blijven vragen tot de gebruiker iets correct ingeeft, en dat is op Dodona niet nodig: de input van een oefening komt uit een vast testgeval en is dus altijd al correct.
 
 In veel opgaves in dit boek is het nuttig om een functie te hebben die
 gebruiker een input laat geven die voldoet aan specifieke eisen. Ik heb

--- a/chapters/28 appendices/06 answers to exercises/description/description.en.md
+++ b/chapters/28 appendices/06 answers to exercises/description/description.en.md
@@ -247,11 +247,12 @@ print( "You entered", len( s ), "characters" )
 #### Answer 5.2
 
 ```python
-from pcinput import getFloat
 from math import sqrt
 
-side1 = getFloat( "Please enter the length of the first side: " )
-side2 = getFloat( "Please enter the length of the second side: ")
+side1 = float( input(
+    "Please enter the length of the first side: " ) )
+side2 = float( input(
+    "Please enter the length of the second side: " ) )
 side3 = sqrt( side1 * side1 + side2 * side2 )
 print( "The length of the diagonal is {:.3f}.".format( side3 ) )
 ```
@@ -259,11 +260,9 @@ print( "The length of the diagonal is {:.3f}.".format( side3 ) )
 #### Answer 5.3
 
 ```python
-from pcinput import getFloat
-
-num1 = getFloat( "Please enter number 1: " )
-num2 = getFloat( "Please enter number 2: " )
-num3 = getFloat( "Please enter number 3: " )
+num1 = float( input( "Please enter number 1: " ) )
+num2 = float( input( "Please enter number 2: " ) )
+num3 = float( input( "Please enter number 3: " ) )
 
 print( "The largest is", max( num1, num2, num3 ) )
 print( "The smallest is", min( num1, num2, num3 ) )
@@ -297,9 +296,7 @@ print( "A random integer between 1 and 10 is",
 #### Answer 6.1
 
 ```python
-from pcinput import getFloat
-
-grade = getFloat( "Please enter a grade: " )
+grade = float( input( "Please enter a grade: " ) )
 check = int( grade * 10 )
 if grade < 0 or grade > 10:
     print( "Grades have to be in the range 0 to 10." )
@@ -326,9 +323,7 @@ incorrect order. E.g., if score is 85, then it is not only greater than
 #### Answer 6.3
 
 ```python
-from pcinput import getString
-
-s = getString( "Please enter a string: " )
+s = input( "Please enter a string: " )
 count = 0
 if ("a" in s) or ("A" in s):
     count += 1
@@ -352,12 +347,11 @@ else:
 #### Answer 6.4
 
 ```python
-from pcinput import getFloat
 from math import sqrt
 
-a = getFloat( "A: " )
-b = getFloat( "B: " )
-c = getFloat( "C: " )
+a = float( input( "A: " ) )
+b = float( input( "B: " ) )
+c = float( input( "C: " ) )
 
 if a == 0:
     if b == 0:
@@ -381,9 +375,7 @@ else:
 #### Answer 7.1
 
 ```python
-from pcinput import getInteger
-
-num = getInteger( "Give a number: " )
+num = int( input( "Give a number: " ) )
 i = 1
 while i <= 10:
     print( i, "*", num, "=", i*num )
@@ -393,9 +385,7 @@ while i <= 10:
 #### Answer 7.2
 
 ```python
-from pcinput import getInteger
-
-num = getInteger( "Give a number: " )
+num = int( input( "Give a number: " ) )
 for i in range( 1, 11 ):
     print( i, "*", num, "=", i*num )
 ```
@@ -403,15 +393,13 @@ for i in range( 1, 11 ):
 #### Answer 7.3
 
 ```python
-from pcinput import getInteger
-
 TOTAL = 10
 largest = 0
 smallest = 0
 div3 = 0
 
 for i in range( TOTAL ):
-    num = getInteger( "Please enter number "+str( i+1 )+": " )
+    num = int( input( "Please enter number "+str( i+1 )+": " ) )
     if num%3 == 0:
         div3 += 1
     if i == 0:
@@ -475,10 +463,8 @@ while True:
 #### Answer 7.6
 
 ```python
-from pcinput import getString
-
-word1 = getString( "Give word 1: " )
-word2 = getString( "Give word 2: " )
+word1 = input( "Give word 1: " )
+word2 = input( "Give word 2: " )
 common = ""
 for letter in word1:
     if (letter in word2) and (letter not in common):
@@ -509,13 +495,12 @@ print( "A reasonable approximation of pi is", 4 * hits / DARTS )
 
 ```python
 from random import randint
-from pcinput import getInteger
 
 answer = randint( 1, 1000 )
 count = 0
 
 while True:
-    guess = getInteger( "What is your guess? " )
+    guess = int( input( "What is your guess? " ) )
     if guess < 1 or guess > 1000:
         print( "Your guess should be between 1 and 1000" )
         continue
@@ -537,7 +522,6 @@ else:
 #### Answer 7.9
 
 ```python
-from pcinput import getLetter
 from sys import exit
 
 count = 0
@@ -550,7 +534,7 @@ while True:
     count += 1
     prompt = "I guess "+str( guess )+". Is your number"+\
         " (L)ower or (H)igher, or is this (C)orrect? "
-    response = getLetter( prompt )
+    response = input( prompt )
     if response == "C":
         break
     elif response == "L":
@@ -576,9 +560,7 @@ else:
 #### Answer 7.10
 
 ```python
-from pcinput import getInteger
-
-num = getInteger( "Please enter a number: " )
+num = int( input( "Please enter a number: " ) )
 if num < 2:
     print( num, "is not prime" )
 else:
@@ -831,8 +813,6 @@ should give 2.33 or 2.34.
 #### Answer 8.1
 
 ```python
-from pcinput import getInteger
-
 # multiplicationtable gets an integer as parameter.
 # It prints the multiplication table for that integer.
 def multiplicationtable( n ):
@@ -841,15 +821,13 @@ def multiplicationtable( n ):
         print( i, "*", n, "=", i*n )
         i += 1
 
-num = getInteger( "Give a number: " )
+num = int( input( "Give a number: " ) )
 multiplicationtable( num )
 ```
 
 #### Answer 8.2
 
 ```python
-from pcinput import getString
-
 # commoncharacters gets two strings as parameters.
 # It returns the number of characters that they have in common.
 def commoncharacters( w1, w2 ):
@@ -859,8 +837,8 @@ def commoncharacters( w1, w2 ):
             common += letter
     return len( common )
 
-word1 = getString( "Give word 1: " )
-word2 = getString( "Give word 2: " )
+word1 = input( "Give word 1: " )
+word2 = input( "Give word 2: " )
 
 num = commoncharacters( word1, word2 )
 if num <= 0:
@@ -893,7 +871,6 @@ print( gregoryLeibnitz( 50 ) )
 #### Answer 8.4
 
 ```python
-from pcinput import getFloat
 from math import sqrt
 
 # This function solves a quadratic equation.
@@ -917,8 +894,8 @@ def quadraticFormula( a, b, c ):
         return 2, (-b+sqrt(discriminant))/(2*a), \
             (-b-sqrt(discriminant))/(2*a)
 
-num, sol1, sol2 = quadraticFormula( getFloat( "A: " ),
-    getFloat( "B: " ), getFloat( "C: " ) )
+num, sol1, sol2 = quadraticFormula( float( input( "A: " ) ),
+    float( input( "B: " ) ), float( input( "C: " ) ) )
 if num == 0:
     print( "There are no solutions" )
 elif num == 1:
@@ -930,11 +907,9 @@ else:
 #### Answer 8.5
 
 ```python
-from pcinput import getInteger
-
 def getNumber( prompt ):
     while True:
-        num = getInteger( prompt )
+        num = int( input( prompt ) )
         if num < 0 or num > 1000:
             print( "Please enter a number between 0 and 1000" )
             continue
@@ -1480,8 +1455,6 @@ for i in numbers:
 #### Answer 12.6
 
 ```python
-from pcinput import getInteger
-
 EMPTY = "-"
 PLAYERX = "X"
 PLAYERO = "O"
@@ -1502,8 +1475,8 @@ def opponent( p ):
 
 def getRowCol( player, what ):
     while True:
-        num = getInteger( "Player "+player+", which "+what+
-            " do you play? " )
+        num = int( input( "Player "+player+", which "+what+
+            " do you play? " ) )
         if num < 1 or num > 3:
             print( "Please enter 1, 2, or 3" )
             continue
@@ -1553,7 +1526,6 @@ while True:
 #### Answer 12.7
 
 ```python
-from pcinput import getString
 from random import randint
 
 EMPTY = "."
@@ -1593,7 +1565,8 @@ def placeBattleships( b ):
 
 def getTarget():
     while True:
-        cell = getString( "Which cell do you target? " ).upper()
+        cell = input(
+            "Which cell do you target? " ).strip().upper()
         if len( cell ) != 2:
             print( "Please enter a cell as XY,",
                 "where X is a letter and Y a digit" )
@@ -2143,7 +2116,6 @@ functionality needs a few lines, while handling of potential problems
 takes three-quarters of the code.
 
 ```python
-from pcinput import getString, getLetter
 from os.path import exists, getsize
 
 LETTERS = b"etaoinshrdlcum "
@@ -2182,7 +2154,7 @@ def decompress( encoded ):
 
 # Ask for the input file and read its contents.
 while True:
-    filein = getString( "Which is the input file? " )
+    filein = input( "Which is the input file? " ).strip()
     if not exists( filein ):
         print( filein, "does not exist" )
         continue
@@ -2198,7 +2170,7 @@ while True:
 
 # Ask for the output file and create it.
 while True:
-    fileout = getString( "Which is the output file? " )
+    fileout = input( "Which is the output file? " ).strip()
     if exists( fileout ):
         print( fileout, "already exists" )
         continue
@@ -2213,7 +2185,8 @@ while True:
 
 # Ask whether the user wants to compress or decompress.
 while True:
-    dc = getLetter( "Choose (C)ompress or (D)ecompress? " )
+    prompt = "Choose (C)ompress or (D)ecompress? "
+    dc = input( prompt ).strip().upper()
     if dc != 'C' and dc != 'D':
         print( "Please choose C or D" )
         continue
@@ -2859,8 +2832,6 @@ print( "Score of", strategy2.name, "is", strategy2.score )
 #### Answer 23.1
 
 ```python
-from pcinput import getInteger
-
 class NotDividableBy:
     def __init__( self ):
         self.seq = list( range( 1, 101 ) )
@@ -2881,7 +2852,7 @@ class NotDividableBy:
 
 ndb = NotDividableBy()
 while True:
-    num = getInteger( "Give an integer: " )
+    num = int( input( "Give an integer: " ) )
     if num < 0:
         print( "Negative integers are ignored" )
         continue
@@ -3225,13 +3196,12 @@ for c in clist:
 
 ```python
 from collections import Counter
-from pcinput import getInteger
 from statistics import mean, median
 from sys import exit
 
 numlist = []
 while True:
-    num = getInteger( "Enter a number: " )
+    num = int( input( "Enter a number: " ) )
     if num == 0:
         break
     numlist.append( num )

--- a/chapters/28 appendices/06 answers to exercises/description/description.nl.md
+++ b/chapters/28 appendices/06 answers to exercises/description/description.nl.md
@@ -258,11 +258,10 @@ print( "Je hebt", len( s ), "letters ingegeven" )
 #### Antwoord 5.2
 
 ```python
-from pcinput import getFloat
 from math import sqrt
 
-zijde1 = getFloat( "Geef de lengte van de eerste zijde: " )
-zijde2 = getFloat( "Geef de lengte van de tweede zijde: " )
+zijde1 = float( input( "Geef de lengte van de eerste zijde: " ) )
+zijde2 = float( input( "Geef de lengte van de tweede zijde: " ) )
 zijde3 = sqrt( zijde1 * zijde1 + zijde2 * zijde2 )
 print( "De lengte van de diagonaal is {:.3f}.".format( zijde3 ) )
 ```
@@ -270,11 +269,9 @@ print( "De lengte van de diagonaal is {:.3f}.".format( zijde3 ) )
 #### Antwoord 5.3
 
 ```python
-from pcinput import getFloat
-
-num1 = getFloat( "Geef nummer 1: " )
-num2 = getFloat( "Geef nummer 2: " )
-num3 = getFloat( "Geef nummer 3: " )
+num1 = float( input( "Geef nummer 1: " ) )
+num2 = float( input( "Geef nummer 2: " ) )
+num3 = float( input( "Geef nummer 3: " ) )
 
 print( "De grootste is", max( num1, num2, num3 ) )
 print( "De kleinste is", min( num1, num2, num3 ) )
@@ -308,9 +305,7 @@ print( "Een toevalsgetal tussen 1 en 10 is",
 #### Antwoord 6.1
 
 ```python
-from pcinput import getFloat
-
-grade = getFloat( "Geef een cijfer: " )
+grade = float( input( "Geef een cijfer: " ) )
 check = int( grade * 10 )
 if grade < 0 or grade > 10:
     print( "Cijfers liggen tussen 0 en 10." )
@@ -338,9 +333,7 @@ uitkomst zal dan "D" zijn.
 #### Antwoord 6.3
 
 ```python
-from pcinput import getString
-
-s = getString( "Geef een string: " )
+s = input( "Geef een string: " )
 count = 0
 if ("a" in s) or ("A" in s):
     count += 1
@@ -364,12 +357,11 @@ else:
 #### Antwoord 6.4
 
 ```python
-from pcinput import getFloat
 from math import sqrt
 
-a = getFloat( "A: " )
-b = getFloat( "B: " )
-c = getFloat( "C: " )
+a = float( input( "A: " ) )
+b = float( input( "B: " ) )
+c = float( input( "C: " ) )
 
 if a == 0:
     if b == 0:
@@ -393,9 +385,7 @@ else:
 #### Antwoord 7.1
 
 ```python
-from pcinput import getInteger
-
-num = getInteger( "Geef een nummer: " )
+num = int( input( "Geef een nummer: " ) )
 i = 1
 while i <= 10:
     print( i, "*", num, "=", i*num )
@@ -405,9 +395,7 @@ while i <= 10:
 #### Antwoord 7.2
 
 ```python
-from pcinput import getInteger
-
-num = getInteger( "Geef een nummer: " )
+num = int( input( "Geef een nummer: " ) )
 for i in range( 1, 11 ):
     print( i, "*", num, "=", i*num )
 ```
@@ -415,15 +403,13 @@ for i in range( 1, 11 ):
 #### Antwoord 7.3
 
 ```python
-from pcinput import getInteger
-
 AANTAL = 10
 grootste = 0
 kleinste = 0
 deelbaar3 = 0
 
 for i in range( AANTAL ):
-    num = getInteger( "Geef nummer "+str( i+1 )+": " )
+    num = int( input( "Geef nummer "+str( i+1 )+": " ) )
     if num%3 == 0:
         deelbaar3 += 1
     if i == 0:
@@ -486,10 +472,8 @@ while True:
 #### Antwoord 7.6
 
 ```python
-from pcinput import getString
-
-woord1 = getString( "Geef woord 1: " )
-woord2 = getString( "Geef woord 2: " )
+woord1 = input( "Geef woord 1: " )
+woord2 = input( "Geef woord 2: " )
 gemeen = ""
 for letter in woord1:
     if (letter in woord2) and (letter not in gemeen):
@@ -521,12 +505,11 @@ print( "Een redelijke benadering van pi is", 4 * raak / DARTS )
 
 ```python
 from random import randint
-from pcinput import getInteger
 
 antwoord = randint( 1, 1000 )
 teller = 0
 while True:
-    poging = getInteger( "Raad een getal: " )
+    poging = int( input( "Raad een getal: " ) )
     if poging < 1 or poging > 1000:
         print( "Je moet een getal tussen de 1 en 1000 noemen" )
         continue
@@ -548,7 +531,6 @@ else:
 #### Antwoord 7.9
 
 ```python
-from pcinput import getLetter
 from sys import exit
 
 teller = 0
@@ -561,7 +543,7 @@ while True:
     teller += 1
     prompt = "Ik raad "+str( poging )+". Is jouw getal"+\
         " (L)ager of (H)oger, of is dit (C)orrect? "
-    antwoord = getLetter( prompt )
+    antwoord = input( prompt )
     if antwoord == "C":
         break
     elif antwoord == "L":
@@ -587,9 +569,7 @@ else:
 #### Antwoord 7.10
 
 ```python
-from pcinput import getInteger
-
-num = getInteger( "Geef een nummer: " )
+num = int( input( "Geef een nummer: " ) )
 if num < 2:
     print( num, "is niet priem" )
 else:
@@ -844,8 +824,6 @@ moet 2.33 of 2.34 geven.
 #### Antwoord 8.1
 
 ```python
-from pcinput import getInteger
-
 # tafel krijgt een integer als parameter. Het drukt de
 # tafel van vermenigvuldiging voor deze integer af.
 def tafel( n ):
@@ -854,15 +832,13 @@ def tafel( n ):
         print( i, "*", n, "=", i*n )
         i += 1
 
-num = getInteger( "Geef een getal: " )
+num = int( input( "Geef een getal: " ) )
 tafel( num )
 ```
 
 #### Antwoord 8.2
 
 ```python
-from pcinput import getString
-
 # gemeen krijgt twee strings als parameters. Het retourneert
 # het aantal tekens dat de strings gemeen hebben.
 def gemeen( w1, w2 ):
@@ -872,8 +848,8 @@ def gemeen( w1, w2 ):
             tekens += letter
     return len( tekens )
 
-woord1 = getString( "Geef woord 1: " )
-woord2 = getString( "Geef woord 2: " )
+woord1 = input( "Geef woord 1: " )
+woord2 = input( "Geef woord 2: " )
 
 num = gemeen( woord1, woord2 )
 if num <= 0:
@@ -906,7 +882,6 @@ print( gregoryLeibnitz( 50 ) )
 #### Antwoord 8.4
 
 ```python
-from pcinput import getFloat
 from math import sqrt
 
 # Deze functie lost een kwadratische vergelijking op.
@@ -930,8 +905,8 @@ def wortelformule( a, b, c ):
         return 2, (-b+sqrt(discriminant))/(2*a), \
             (-b-sqrt(discriminant))/(2*a)
 
-num, opl1, opl2 = wortelformule( getFloat( "A: " ),
-    getFloat( "B: " ), getFloat( "C: " ) )
+num, opl1, opl2 = wortelformule( float( input( "A: " ) ),
+    float( input( "B: " ) ), float( input( "C: " ) ) )
 if num == 0:
     print( "Er zijn geen oplossingen" )
 elif num == 1:
@@ -943,11 +918,9 @@ else:
 #### Antwoord 8.5
 
 ```python
-from pcinput import getInteger
-
 def getNummer( prompt ):
     while True:
-        num = getInteger( prompt )
+        num = int( input( prompt ) )
         if num < 0 or num > 1000:
             print( "Geef een getal tussen 1 en 1000" )
             continue
@@ -1497,8 +1470,6 @@ for i in nummers:
 #### Antwoord 12.6
 
 ```python
-from pcinput import getInteger
-
 LEEG = "-"
 SPELERX = "X"
 SPELERO = "O"
@@ -1519,8 +1490,8 @@ def opponent( p ):
 
 def neemRowKolom( speler, wat ):
     while True:
-        num = getInteger( "Speler "+speler+", welke "+wat+
-            " kies je? " )
+        num = int( input( "Speler "+speler+", welke "+wat+
+            " kies je? " ) )
         if num < 1 or num > 3:
             print( "Geef 1, 2, of 3" )
             continue
@@ -1568,7 +1539,6 @@ while True:
 #### Antwoord 12.7
 
 ```python
-from pcinput import getString
 from random import randint
 
 LEEG = "."
@@ -1608,7 +1578,8 @@ def plaatsSchepen( b ):
 
 def neemDoel():
     while True:
-        cel = getString( "Welke cel kies je? " ).upper()
+        cel = input(
+            "Welke cel kies je? " ).strip().upper()
         if len( cel ) != 2:
             print( "Geef een cel in als XY,",
                 "met X een letter en Y een cijfer" )
@@ -2171,7 +2142,6 @@ vaak in een paar regels schrijven, terwijl foutafhandeling drie keer zo
 lang is.
 
 ```python
-from pcinput import getString, getLetter
 from os.path import exists, getsize
 
 LETTERS = b"etaoinshrdlcum "
@@ -2210,7 +2180,7 @@ def decomprimeer( gecodeerd ):
 
 # Vraag om input bestand en lees de inhoud
 while True:
-    filein = getString( "Geef input bestand: " )
+    filein = input( "Geef input bestand: " ).strip()
     if not exists( filein ):
         print( filein, "bestaat niet" )
         continue
@@ -2226,7 +2196,7 @@ while True:
 
 # Vraag om output bestand en creeer het
 while True:
-    fileout = getString( "Geef output bestand: " )
+    fileout = input( "Geef output bestand: " ).strip()
     if exists( fileout ):
         print( fileout, "bestaat al" )
         continue
@@ -2241,7 +2211,8 @@ while True:
 
 # Vraag of de gebruiker wil comprimeren of decomprimeren.
 while True:
-    dc = getLetter( "Wil je (C)omprimeren of (D)ecomprimeren? " )
+    prompt = "Wil je (C)omprimeren of (D)ecomprimeren? "
+    dc = input( prompt ).strip().upper()
     if dc != 'C' and dc != 'D':
         print( "Kies C of D" )
         continue
@@ -2887,8 +2858,6 @@ print( "Score van", strategie2.naam, "is", strategie2.score )
 #### Antwoord 23.1
 
 ```python
-from pcinput import getInteger
-
 class NietDeelbaarDoor:
     def __init__( self ):
         self.seq = list( range( 1, 101 ) )
@@ -2909,7 +2878,7 @@ class NietDeelbaarDoor:
 
 ndd = NietDeelbaarDoor()
 while True:
-    num = getInteger( "Geef een getal: " )
+    num = int( input( "Geef een getal: " ) )
     if num < 0:
         print( "Negatieve getallen worden overgeslagen" )
         continue
@@ -3252,13 +3221,12 @@ for c in clist:
 
 ```python
 from collections import Counter
-from pcinput import getInteger
 from statistics import mean, median
 from sys import exit
 
 numlist = []
 while True:
-    num = getInteger( "Geef een getal: " )
+    num = int( input( "Geef een getal: " ) )
     if num == 0:
         break
     numlist.append( num )


### PR DESCRIPTION
`pcinput` is a helper module from the printed book: `getInteger()`, `getFloat()`, `getString()` and `getLetter()`, which keep asking until the user types something valid. There is no `pcinput.py` anywhere in this repository (`find . -iname "pcinput*"` returns nothing), so `from pcinput import ...` in a submission fails with an import error unconditionally. Every reading activity that showed such an import was showing code that cannot run here.

Two things, on #306:

**1. The `### pcinput` section now puts Dodona first.** It leads with an info callout on reading input with `input()` plus casting, then the four equivalences as a table, then a sentence scoping the rest: the explanation below applies only when you run the exercises in your own environment, outside Dodona, with `pcinput.py` saved next to your own code. The book's explanation itself is kept as it was, not deleted. Per the follow-up: *"Dodona is first citizen here, so having a whole paragraph on 'this is pcinput, download it, and use it, oh and by the way, it's not required on dodona', we should lead that `### pcinput` paragraph with an info callout on the use of input in dodona, and that the paragraph is only valid for people running the exercises on their own environments"*. The appendix got the same scoping in its opening note.

**2. The example code that imported the module is converted to `input()` plus casting**, so a reader can run what the page shows. This was not a find and replace: every site was weighed against what its own chapter has taught, since the sites span chapters 6 to 17 and string methods are not taught until chapter 10.

The reason given to readers is concrete: the module's whole purpose is to keep asking until the input is valid, and on Dodona the input of an exercise comes from a fixed test case instead of from a person typing at the keyboard, so it is always valid already and there is nothing to retry.

<details>
<summary>Per-site decisions (9 activities, both languages)</summary>

| activity | imports removed (en + nl) | decision |
|---|---|---|
| `chapters/06 conditions/02 conditional statements` | prose only | Dropped the dangling instruction that still told readers to use `getInteger()` from `pcinput`. Not on the original list of 8, but leaving it would have left chapter 6 pointing at a module nothing else in the chapter uses. |
| `chapters/06 conditions/03 early exits` | 2 + 2 | Both blocks only ever needed a number. The lesson is `exit()`, untouched. |
| `chapters/07 iterations/01 while loop` | 4 + 4 | Only numbers needed; the lesson is the loop. Reworded the prose that called out "the repetition of the `getInteger()` function" to "the repetition of the line that asks for a number", since that observation is about the repeated input line, not about the module. |
| `chapters/07 iterations/05 the loop-and-a-half` | 3 + 3 | Same. Reworded the exercise prose that told the reader to use `getInteger()` and noted "this function also allows entering negative numbers", which is still true of `int( input() )`. |
| `chapters/08 functions/02 definition` | 1 + 1 | Only numbers needed; the lesson is `return`. |
| `chapters/08 functions/08 exercises/05 loop-and-a-half` | 1 + 1 | An exercise, not a reading activity. Converted the "before" code, and dropped `getInteger` from the assignment text (and from the Dutch hint), since it prescribed a module that does not exist. `evaluation/`, both solutions and the generator are untouched: the suite only ever tests `get_valid_number` and `main` with `input()` monkeypatched, so the reference solution's own local helper stays an implementation detail. |
| `chapters/17 exceptions/01 errors and exceptions` | 2 + 2 | See the chapter 17 note below. |
| `chapters/17 exceptions/02 exception handling` | 2 + 2 | See the chapter 17 note below. |
| `chapters/28 appendices/06 answers to exercises` | 21 + 21 | 21 answers per language. Every answer stays an answer to the question as posed. |

**Chapter 17.** Converting here is a small improvement rather than a compromise. The chapter's later sections already write `print( 3 / int( input( ... ) ) )` and explicitly teach that it raises `ValueError` when you enter something that is not an integer. The earlier examples used a module that swallowed exactly that exception, which is odd in a chapter about exceptions. Now the whole chapter uses the same construct and the `ValueError` discussion applies to all of its code.

**`getString()` / `getLetter()` in the answers appendix.** These two do more than read a line, so each of the 10 sites was decided separately:

- `.strip()` kept where the code depends on it: the two filenames in answer 18.4 (a trailing space breaks the path) and the battleship cell in answer 12.7 (which tests `len( cell ) != 2`).
- `.strip().upper()` kept for the `(C)`/`(D)` choice in answer 18.4, which compares against capitals.
- Dropped in answers 6.3, 7.6, 7.9 and 8.2, both because nothing there depends on it and because `strip()` and `upper()` are not taught until chapter 10 (`grep -rl "strip(" chapters --include=description.en.md` only hits chapter 10 and 26). Answer 7.9 compares against capitals and its `else` branch already tells the user to answer H, L or C, and the Dodona exercise for it says to read the answer with `input()` and feeds capitals, so plain `input( prompt )` is right there.
- Four lines went over the appendix's 65-character code width after conversion and were wrapped, one of them by pulling the prompt into a `prompt` variable, which is an idiom the appendix already uses.

</details>

## Verification

No judge for the reading activities, so:

- `git diff --name-only` over the whole branch is 24 files, all `description.en.md` / `description.nl.md`, paired for all 12 pages. No `evaluation/`, no `solution/`, no `config.json`, no generator.
- Every ```python block in every changed file was extracted and compiled with `compile()`: 323 OK, 16 skipped as the book's deliberate syntax templates (`while <boolean expression>:`), 1 pre-existing failure in `chapters/06 conditions/02 conditional statements` (an indented fragment that is identical on `master`, and that file only got a prose change here).
- No `from pcinput` / `import pcinput` left anywhere except the modules page's own book example, which is deliberate and now sits under the scoping callout.
- Grepping the diff for an em-dash finds nothing.
- The chapter 8 exercise still passes in both languages:

```
$ python3 scripts/verify_pythia_exercise.py "chapters/08 functions/08 exercises/05 loop-and-a-half" \
      ".../solution/solution.en.py" --no-pull
33 passed, 0 failed
submission status: correct answer (accepted: True)
judge says: All tests succeeded
OK: all tests passed

$ ... --expect-fail with a stub
18 passed, 15 failed
submission status: wrong answer (accepted: False)
OK: the solution was rejected, as expected
```

Dutch, driving the judge container with `natural_language=nl`: `accepted=True`, `judge='Alle testen geslaagd'`, 30 leaf tests correct, same as the English run.

## Still outstanding

`pcmaze` has the identical problem and is not covered by #306: `chapters/09 recursion/02 recursive definitions` tells the reader to create or download it "from the same place where you got `pcinput.py`", and there is no `pcmaze.py` in this repository either. Worth its own issue, deliberately not fixed here.

Deliberately left as book context, since they are about running things outside Dodona or are historical: the `pcinput` mentions in `chapters/28 appendices/01 troubleshooting` (import-error troubleshooting), `chapters/09 recursion/02 recursive definitions` (the `pcmaze` pointer), and `chapters/00 prologue/03 contributors` (a contributor credit). Also the `(This is pcinput.getInteger().)` docstring line in both solutions of the chapter 8 exercise, which is out of scope while `solution/` is off limits.

One pre-existing typo fixed along the way, on a line this PR already rewrites: `chapters/17 exceptions/02 exception handling/description/description.nl.md` prompted `"Geen een getal: "` where it means `"Geef een getal: "`. The other seven prompts in that same file already read `"Geef een getal: "`, and the English file has `"Please enter a number: "` there. `grep -rn "Geen een" chapters` finds no other instance.

`Refs #306`, still not `Closes #306`: the issue asks to drop all use of the module. The explanation is now book-scoped and every usage site is converted, but the module is still explained and still shown in one runnable book example on the modules page, so the owner should decide whether that counts as done.

