### PR TITLE
Show which course is missing when the enrollment sets differ

### DIFF
--- a/chapters/20 object orientation/06 exercises/02 enrollments/evaluation/2.in
+++ b/chapters/20 object orientation/06 exercises/02 enrollments/evaluation/2.in
@@ -6,43 +6,113 @@
 >>> harry = Student(29839339, 'Harry', 'Potter', datetime.date(1980, 7, 31))
 >>> hermione = Student(24837367, 'Hermione', 'Granger', datetime.date(1979, 9, 19))
 >>> ron = Student(27373378, 'Ron', 'Weasley', datetime.date(1980, 3, 1))
->>> hermione.enroll(astronomy).courses() == {astronomy}
-True
->>> harry.enroll(defence_against_dark_arts).courses() == {defence_against_dark_arts}
-True
->>> ron.enroll(dark_arts).courses() == {dark_arts}
-True
->>> hermione.enroll(astronomy).enroll(dark_arts).courses() == {astronomy, dark_arts}
-True
->>> hermione.enroll(dark_arts).enroll(charms).courses() == {astronomy, charms, dark_arts}
-True
->>> harry.enroll(charms).courses() == {charms, defence_against_dark_arts}
-True
->>> harry.enroll(astronomy).courses() == {astronomy, charms, defence_against_dark_arts}
-True
->>> hermione.enroll(charms).courses() == {astronomy, charms, dark_arts}
-True
->>> ron.enroll(charms).courses() == {charms, dark_arts}
-True
->>> hermione.enroll(dark_arts).courses() == {astronomy, charms, dark_arts}
-True
->>> ron.enroll(defence_against_dark_arts).courses() == {charms, dark_arts, defence_against_dark_arts}
-True
->>> ron.enroll(charms).courses() == {charms, dark_arts, defence_against_dark_arts}
-True
->>> ron.enroll(defence_against_dark_arts).courses() == {charms, dark_arts, defence_against_dark_arts}
-True
->>> ron.enroll(astronomy).courses() == {astronomy, charms, dark_arts, defence_against_dark_arts}
-True
->>> hermione.enroll(defence_against_dark_arts).courses() == {astronomy, charms, dark_arts, defence_against_dark_arts}
-True
->>> ron.enroll(dark_arts).courses() == {astronomy, charms, dark_arts, defence_against_dark_arts}
-True
->>> hermione.enroll(charms).courses() == {astronomy, charms, dark_arts, defence_against_dark_arts}
-True
->>> harry.enroll(dark_arts).courses() == {astronomy, charms, dark_arts, defence_against_dark_arts}
-True
->>> harry.enroll(astronomy).courses() == {astronomy, charms, dark_arts, defence_against_dark_arts}
-True
->>> ron.enroll(charms).courses() == {astronomy, charms, dark_arts, defence_against_dark_arts}
-True
+>>> hermione.enroll(astronomy).courses()
+<DEFINITION>
+class CourseSetChecker(OutputProcessor):
+
+    """
+    Compares the set of courses returned by the submission with the set of
+    courses that was expected. Both sets are compared as sorted lists of the
+    string representations of the courses they contain, and are also shown that
+    way in the feedback table. Two reasons for not comparing the sets of courses
+    themselves:
+
+      - the judge deep copies the expected value before comparing it, so the
+        expected set holds other course objects than the ones the submission
+        put in its own set; comparing the sets themselves would then only
+        succeed if the submission defines equality and hashing on its course
+        class, which this exercise doesn't ask for (chapter 21)
+      - a set has no fixed iteration order, so the order in which the courses
+        of the expected and the generated set show up in the feedback table
+        would otherwise be arbitrary and could differ between both sets
+
+    Comparing the string representations is safe here, since the exercise
+    already requires the representation of a course to hold both its identifier
+    and its name, and a separate tab checks that representation.
+    """
+
+    def representations(self, courses):
+
+        # sorted list of the string representations of the given courses
+        return sorted(repr(course) for course in courses)
+
+    def format(self, courses):
+
+        # set notation with the courses in the order in which they are compared
+        if not courses:
+            return 'set()'
+
+        return '{' + ', '.join(self.representations(courses)) + '}'
+
+    def checkReturnValue(self, expected_return, generated_return, **parameters):
+
+        if not (
+            isinstance(expected_return, set) and
+            isinstance(generated_return, set)
+        ):
+
+            # fall back on the default comparison if no set of courses was
+            # returned; the type check has already reported that error
+            return super().checkReturnValue(
+                expected_return,
+                generated_return,
+                **parameters
+            )
+
+        # show both sets of courses in the order in which they are compared, so
+        # that a missing or a superfluous course is easy to spot
+        self.setOutput(
+            channel='return',
+            expected=[self.format(expected_return)],
+            generated=[self.format(generated_return)],
+            split=True,
+            escaped=False
+        )
+
+        return (
+            self.representations(expected_return) ==
+            self.representations(generated_return)
+        )
+</DEFINITION>
+<OUTPUTPROCESSOR sticky="sticky">
+CourseSetChecker()
+</OUTPUTPROCESSOR>
+{Course(238273, 'Astronomy')}
+>>> harry.enroll(defence_against_dark_arts).courses()
+{Course(462763, 'Defence Against Dark Arts')}
+>>> ron.enroll(dark_arts).courses()
+{Course(746473, 'Dark Arts')}
+>>> hermione.enroll(astronomy).enroll(dark_arts).courses()
+{Course(238273, 'Astronomy'), Course(746473, 'Dark Arts')}
+>>> hermione.enroll(dark_arts).enroll(charms).courses()
+{Course(238273, 'Astronomy'), Course(746473, 'Dark Arts'), Course(983448, 'Charms')}
+>>> harry.enroll(charms).courses()
+{Course(462763, 'Defence Against Dark Arts'), Course(983448, 'Charms')}
+>>> harry.enroll(astronomy).courses()
+{Course(238273, 'Astronomy'), Course(462763, 'Defence Against Dark Arts'), Course(983448, 'Charms')}
+>>> hermione.enroll(charms).courses()
+{Course(238273, 'Astronomy'), Course(746473, 'Dark Arts'), Course(983448, 'Charms')}
+>>> ron.enroll(charms).courses()
+{Course(746473, 'Dark Arts'), Course(983448, 'Charms')}
+>>> hermione.enroll(dark_arts).courses()
+{Course(238273, 'Astronomy'), Course(746473, 'Dark Arts'), Course(983448, 'Charms')}
+>>> ron.enroll(defence_against_dark_arts).courses()
+{Course(462763, 'Defence Against Dark Arts'), Course(746473, 'Dark Arts'), Course(983448, 'Charms')}
+>>> ron.enroll(charms).courses()
+{Course(462763, 'Defence Against Dark Arts'), Course(746473, 'Dark Arts'), Course(983448, 'Charms')}
+>>> ron.enroll(defence_against_dark_arts).courses()
+{Course(462763, 'Defence Against Dark Arts'), Course(746473, 'Dark Arts'), Course(983448, 'Charms')}
+>>> ron.enroll(astronomy).courses()
+{Course(238273, 'Astronomy'), Course(462763, 'Defence Against Dark Arts'), Course(746473, 'Dark Arts'), Course(983448, 'Charms')}
+>>> hermione.enroll(defence_against_dark_arts).courses()
+{Course(238273, 'Astronomy'), Course(462763, 'Defence Against Dark Arts'), Course(746473, 'Dark Arts'), Course(983448, 'Charms')}
+>>> ron.enroll(dark_arts).courses()
+{Course(238273, 'Astronomy'), Course(462763, 'Defence Against Dark Arts'), Course(746473, 'Dark Arts'), Course(983448, 'Charms')}
+>>> hermione.enroll(charms).courses()
+{Course(238273, 'Astronomy'), Course(462763, 'Defence Against Dark Arts'), Course(746473, 'Dark Arts'), Course(983448, 'Charms')}
+>>> harry.enroll(dark_arts).courses()
+{Course(238273, 'Astronomy'), Course(462763, 'Defence Against Dark Arts'), Course(746473, 'Dark Arts'), Course(983448, 'Charms')}
+>>> harry.enroll(astronomy).courses()
+{Course(238273, 'Astronomy'), Course(462763, 'Defence Against Dark Arts'), Course(746473, 'Dark Arts'), Course(983448, 'Charms')}
+>>> ron.enroll(charms).courses()
+{Course(238273, 'Astronomy'), Course(462763, 'Defence Against Dark Arts'), Course(746473, 'Dark Arts'), Course(983448, 'Charms')}

--- a/chapters/20 object orientation/06 exercises/02 enrollments/preparation/courseSetChecker.py
+++ b/chapters/20 object orientation/06 exercises/02 enrollments/preparation/courseSetChecker.py
@@ -1,0 +1,65 @@
+class CourseSetChecker(OutputProcessor):
+
+    """
+    Compares the set of courses returned by the submission with the set of
+    courses that was expected. Both sets are compared as sorted lists of the
+    string representations of the courses they contain, and are also shown that
+    way in the feedback table. Two reasons for not comparing the sets of courses
+    themselves:
+
+      - the judge deep copies the expected value before comparing it, so the
+        expected set holds other course objects than the ones the submission
+        put in its own set; comparing the sets themselves would then only
+        succeed if the submission defines equality and hashing on its course
+        class, which this exercise doesn't ask for (chapter 21)
+      - a set has no fixed iteration order, so the order in which the courses
+        of the expected and the generated set show up in the feedback table
+        would otherwise be arbitrary and could differ between both sets
+
+    Comparing the string representations is safe here, since the exercise
+    already requires the representation of a course to hold both its identifier
+    and its name, and a separate tab checks that representation.
+    """
+
+    def representations(self, courses):
+
+        # sorted list of the string representations of the given courses
+        return sorted(repr(course) for course in courses)
+
+    def format(self, courses):
+
+        # set notation with the courses in the order in which they are compared
+        if not courses:
+            return 'set()'
+
+        return '{' + ', '.join(self.representations(courses)) + '}'
+
+    def checkReturnValue(self, expected_return, generated_return, **parameters):
+
+        if not (
+            isinstance(expected_return, set) and
+            isinstance(generated_return, set)
+        ):
+
+            # fall back on the default comparison if no set of courses was
+            # returned; the type check has already reported that error
+            return super().checkReturnValue(
+                expected_return,
+                generated_return,
+                **parameters
+            )
+
+        # show both sets of courses in the order in which they are compared, so
+        # that a missing or a superfluous course is easy to spot
+        self.setOutput(
+            channel='return',
+            expected=[self.format(expected_return)],
+            generated=[self.format(generated_return)],
+            split=True,
+            escaped=False
+        )
+
+        return (
+            self.representations(expected_return) ==
+            self.representations(generated_return)
+        )

--- a/chapters/20 object orientation/06 exercises/02 enrollments/preparation/generator.py
+++ b/chapters/20 object orientation/06 exercises/02 enrollments/preparation/generator.py
@@ -113,7 +113,7 @@ for student in students:
     obj = test_instantiation(Student, *student, varname=varname, newcontext=False)
     student_dict[varname] = obj
 
-for _ in range(20):
+for index in range(20):
 
     student_name, student = random.choice(list(student_dict.items()))
     r = 1 if random.random() < 0.8 else 2
@@ -126,20 +126,25 @@ for _ in range(20):
         student.enroll(course)
     statement += '.courses()'
 
-    # let the submission itself compare the returned set against a set of the
-    # courses that are already bound in the context, so the expected value of
-    # the test is just the bool True. Two reasons for not simply printing the
-    # repr of the returned set as the expected value:
-    #
-    #   - the iteration order of a set is arbitrary, and printing its repr
-    #     would bake one particular order into the test
-    #   - the judge deep copies the expected value before comparing it, so an
-    #     expected set of courses only ever matches if the submission defines
-    #     equality and hashing on the course class, which the assignment
-    #     doesn't ask for
-    enrolled = student_dict[student_name].courses()
-    names = [name for name, course in course_dict.items() if course in enrolled]
-    statement += ' == {{{}}}'.format(', '.join(names))
-
     print(statement)
-    print('True')
+
+    # the returned set of courses is compared by a custom output processor
+    # instead of by the judge itself, since the judge can only compare the
+    # courses in both sets if the submission defines equality and hashing on
+    # its course class, which the exercise doesn't ask for; the processor is
+    # made sticky so that it doesn't have to be repeated for every test (see
+    # courseSetChecker.py for the details)
+    if not index:
+        print('<DEFINITION>')
+        with open('courseSetChecker.py') as checker:
+            print(checker.read().rstrip())
+        print('</DEFINITION>')
+        print('<OUTPUTPROCESSOR sticky="sticky">')
+        print('CourseSetChecker()')
+        print('</OUTPUTPROCESSOR>')
+
+    # generate test result, with the courses sorted by their representation so
+    # that the expected value doesn't depend on the arbitrary iteration order
+    # of a set
+    enrolled = student_dict[student_name].courses()
+    print('{{{}}}'.format(', '.join(sorted(repr(course) for course in enrolled))))


### PR DESCRIPTION
Follow-up on the fix for #330 that's already on master (#338), not a fix for a broken exercise: 20.2 "Enrollments" accepts correct submissions again since that one landed. This is about the feedback you flagged afterwards, that a student who forgets a course now only reads "expected `True`, got `False`".

The tests ask for the returned set again, and the comparison moves into a custom output processor (`preparation/courseSetChecker.py`, inlined into `evaluation/2.in` by the generator). It compares both sets as sorted lists of the string representations of the courses they hold, and shows both sets in set notation with the courses in that same order.

### Feedback for a student who forgets to enroll a course

Same submission both times (it silently skips the first course a student ever enrolls in), values taken straight from the judge's JSON output.

Before, on master:

```
statement: harry.enroll(charms).courses() == {charms, defence_against_dark_arts}
expected : True
generated: False
```

After, on this branch:

```
statement: harry.enroll(charms).courses()
expected : {Course(462763, 'Defence Against Dark Arts'), Course(983448, 'Charms')}
generated: {Course(983448, 'Charms')}
```

One with more courses in play:

```
statement: ron.enroll(astronomy).courses()
expected : {Course(238273, 'Astronomy'), Course(462763, 'Defence Against Dark Arts'), Course(746473, 'Dark Arts'), Course(983448, 'Charms')}
generated: {Course(238273, 'Astronomy'), Course(462763, 'Defence Against Dark Arts'), Course(983448, 'Charms')}
```

### Why the order can't come back

Two things kept the order out of the tests, and both are still there:

1. the processor compares (and shows) the courses of both sets sorted by their representation, so neither the verdict nor the feedback depends on the iteration order of a set. The expected values in `2.in` are written in that same sorted order, so the generator's output doesn't depend on it either.
2. the courses themselves are never compared, so the submission still doesn't need equality and hashing on its course class. That's the actual cause of #330: the judge deep copies the expected value, so the expected set holds other course objects than the ones the submission put in its own set, and only value based `__eq__`/`__hash__` (chapter 21) would have made that match.

The statements are back to what the description shows, so the student no longer has to read past a comparison in the test, and no construct in there is newer than chapter 20. The judge's own type check still fires, so returning a `list` is still rejected.

<details>
<summary>Trade-off I accepted, and the alternatives</summary>

The judge does have order free set comparison (`content_checker.set_compare`, picked automatically for set typed expected values), so a set of *primitives* would have worked without any processor. But `courses()` returns courses, so the test would then have to map them to something primitive, e.g. `set([str(course) for course in harry.courses()])`. That works and only uses taught constructs (list comprehension is chapter 12), but the student reads that expression in the feedback table, and the columns then show sets of quoted strings in arbitrary order. `sorted()` isn't an option to make that order stable, it only shows up in chapter 23.

Comparing on the representation of a course does mean a submission that doesn't define `__repr__` fails these tests too, on top of the "Course" tab that checks the representation. The representation is the only handle on a course the exercise defines (comparing on attributes would require attribute names the exercise never names, and `vars()` would silently accept everything for a submission whose courses have no attributes), so this seemed the right way round.
</details>

### Testing

```sh
D="chapters/20 object orientation/06 exercises/02 enrollments"

# reference solution passes
python3 scripts/verify_pythia_exercise.py "$D" "$D/solution/solution.en.py" --no-pull
```

Ran here with these results:

- reference solution: 58 passed, 0 failed, accepted, and 10 out of 10 runs in a row accepted (set order can differ between processes)
- a correct submission without `__eq__`/`__hash__` on `Course`: accepted, also 10 out of 10 runs
- a correct submission that builds its set in reverse insertion order: accepted
- rejected: an empty stub (37 failures), the forgot a course submission above (12), one that enrolls a spurious extra course (20), one that returns a `list` instead of a `set` (23, with "Error: expected return type set")
- both languages, driving the judge directly since the script hardcodes `natural_language=en`: `nl` and `en` both `accepted: True`, and the `nl` feedback shows the translated identifiers (`{Cursus(746473, 'Dark Arts'), ...}`, `ron.inschrijven(...).cursussen()`), so the `<LANGUAGE>` block in `2.out` still fires
- `preparation/generator.py` reproduces the committed `evaluation/2.in` and `0.in` byte for byte (copy `preparation/` and `solution/` to a throwaway dir, run it there, `cmp`). `1.in` still differs in the three hard coded ages (39/40/40 versus 45/46/46), which is pre-existing and date dependent: `AgeChecker` recomputes the expected age at runtime, so those numbers in the file are never used. Left them alone to keep the diff small.

`Refs #330`. The issue is already closed by #338, so you may want to reopen it or track this separately.
