### PR TITLE
Give same-titled activities distinct names

### DIFF
--- a/chapters/01 introduction/10 exercises/02 sorting cards/config.json
+++ b/chapters/01 introduction/10 exercises/02 sorting cards/config.json
@@ -1,8 +1,8 @@
 {
   "description": {
     "names": {
-      "nl": "Kaarten sorteren",
-      "en": "Sorting cards"
+      "nl": "Instructies om kaarten te sorteren",
+      "en": "Instructions for sorting cards"
     }
   },
   "labels": [

--- a/chapters/06 conditions/05 exercises/02 letter grades/config.json
+++ b/chapters/06 conditions/05 exercises/02 letter grades/config.json
@@ -1,8 +1,8 @@
 {
   "description": {
     "names": {
-      "nl": "Letterscores",
-      "en": "Letter grades"
+      "nl": "Letterscores: zoek de fout",
+      "en": "Letter grades: spot the error"
     }
   },
   "labels": [

--- a/chapters/07 iterations/10 exercises/02 multiplication tables/config.json
+++ b/chapters/07 iterations/10 exercises/02 multiplication tables/config.json
@@ -1,8 +1,8 @@
 {
   "description": {
     "names": {
-      "nl": "Tafels van vermenigvuldiging",
-      "en": "Multiplication tables"
+      "nl": "Tafels van vermenigvuldiging met een andere lus",
+      "en": "Multiplication tables with another loop"
     }
   },
   "labels": [

--- a/chapters/07 iterations/10 exercises/11 multiplication tables/config.json
+++ b/chapters/07 iterations/10 exercises/11 multiplication tables/config.json
@@ -1,8 +1,8 @@
 {
   "description": {
     "names": {
-      "nl": "Tafels van vermenigvuldiging",
-      "en": "Multiplication tables"
+      "nl": "Vermenigvuldigingsrooster",
+      "en": "Multiplication grid"
     }
   },
   "labels": [

--- a/chapters/09 recursion/04 exercises/02 fibonacci numbers/config.json
+++ b/chapters/09 recursion/04 exercises/02 fibonacci numbers/config.json
@@ -1,8 +1,8 @@
 {
   "description": {
     "names": {
-      "nl": "Fibonaccigetallen",
-      "en": "Fibonacci numbers"
+      "nl": "Fibonaccigetallen traceren",
+      "en": "Tracing Fibonacci numbers"
     }
   },
   "labels": [

--- a/chapters/16 text files/08 exercises/02 counting words/config.json
+++ b/chapters/16 text files/08 exercises/02 counting words/config.json
@@ -1,8 +1,8 @@
 {
   "description": {
     "names": {
-      "nl": "Woorden tellen",
-      "en": "Counting words"
+      "nl": "Woorden tellen regel per regel",
+      "en": "Counting words line by line"
     }
   },
   "labels": [


### PR DESCRIPTION
Some series showed the same activity title twice, in both languages, so students had no way to tell the two apart in the listing. Spotted on "Sorting cards" in chapter 1, and a sweep over all 294 `config.json` files turned up four more.

They all have the same shape: the first activity has you write the program, the follow-up gives you a variant task on the same problem, and the follow-up just kept the first one's title. So the fix is to name each follow-up after what it actually asks you to do, and leave the first one alone as the canonical title.

| Chapter | Was | Now (EN / NL) | What the follow-up actually asks |
|---|---|---|---|
| 1 | Sorting cards | Instructions for sorting cards / Instructies om kaarten te sorteren | write the instructions down and have a third person follow them literally |
| 6 | Letter grades | Letter grades: spot the error / Letterscores: zoek de fout | debug the buggy `if`/`elif` chain given as boilerplate |
| 7 | Multiplication tables | Multiplication tables with another loop / Tafels van vermenigvuldiging met een andere lus | redo it with `while` if you used `for`, and vice versa |
| 7 | Multiplication tables | Multiplication grid / Vermenigvuldigingsrooster | a different exercise altogether: the 2D grid with aligned columns |
| 9 | Fibonacci numbers | Tracing Fibonacci numbers / Fibonaccigetallen traceren | add a depth parameter and print the indented call tree |
| 16 | Counting words | Counting words line by line / Woorden tellen regel per regel | same assignment, but processing the text line by line |

Chapter 7 had *three* activities called "Multiplication tables", which is why two of them are renamed there.

Only `description.names` changes. No description, solution, test or `internals.token` is touched, so this is a display-name change and nothing needs re-verifying against the judge.

The names are a proposal and easy to bikeshed. The two commits are split so the chapter 1 fix can stand on its own if you'd rather land the rest separately.

## Testing

Nothing to run. Verified mechanically:

<details>
<summary>Verification output</summary>

```
config.json files : 294
invalid JSON      : none
missing token     : none
duplicate EN names within a series: none
duplicate NL names within a series: none
```

```
$ git diff origin/master -- '*config.json' | grep -E "^[-+].*token"
  no token lines touched
```

```
 6 files changed, 12 insertions(+), 12 deletions(-)
```

</details>

To check on Dodona: open the chapter 1, 6, 7, 9 and 16 exercise series and confirm each title now reads distinctly, in both `nl` and `en`.
