### PR TITLE
Put Dodona first and make the local Python setup optional

### DIFF
--- a/chapters/01 introduction/01 how to use this book/description/description.en.md
+++ b/chapters/01 introduction/01 how to use this book/description/description.en.md
@@ -41,10 +41,12 @@ from which you can pick and choose, though I recommend that you at least
 read through them to understand the topics that they cover. Future
 editions of this book may have extra optional material added to the end.
 
-When studying this book, you should have a computer with Python
-installed at hand (Chapter
+When studying this book, everything you need is already on Dodona: you
+write your code in the browser, run it there, and hand it in, without
+installing anything (Chapter
 3
-explains how to get Python for your computer). The book contains many
+explains how to get Python for your own computer as well, if you would
+also like to work outside the course). The book contains many
 small and larger exercises, and you should do all of those while
 studying. There is no way that you will learn how to program if you skip
 the exercises. More on the exercises follows later in this chapter
@@ -55,9 +57,10 @@ Many of the code snippets in this book – in particular all the answers
 to the exercises and all the slightly longer pieces of code – have a
 file name listed as a caption. This means that this code is available
 under that particular file name from the website associated with this
-book (<http://www.spronck.net/pythonbook>{:target="_blank"}). You can download this code
-and load it immediately in the editor that you are using if you so wish.
+book (<http://www.spronck.net/pythonbook>{:target="_blank"}). If you work on your own
+computer, you can download this code and load it immediately in the
+editor that you are using if you so wish.
 
 {:class="callout callout-info"}
 > #### Note
-> **Note that copying and pasting code from a PDF file to an editor will, in general, not work.** Text in a PDF file is not stored in such a way that spaces are inserted in the correct places when you copy code. So you must either manually type in code, or use the listings that are provided as separate files.
+> **If you are reading this book as a PDF, note that copying and pasting code from a PDF file to an editor will, in general, not work.** Text in a PDF file is not stored in such a way that spaces are inserted in the correct places when you copy code. So you must either manually type in code, or use the listings that are provided as separate files. This does not apply to the code on Dodona, which you can copy as it is.

--- a/chapters/01 introduction/01 how to use this book/description/description.en.md
+++ b/chapters/01 introduction/01 how to use this book/description/description.en.md
@@ -43,10 +43,9 @@ editions of this book may have extra optional material added to the end.
 
 When studying this book, everything you need is already on Dodona: you
 write your code in the browser, run it there, and hand it in, without
-installing anything (Chapter
-3
-explains how to get Python for your own computer as well, if you would
-also like to work outside the course). The book contains many
+installing anything (the next chapter explains how to get Python for
+your own computer as well, if you would also like to work outside the
+course). The book contains many
 small and larger exercises, and you should do all of those while
 studying. There is no way that you will learn how to program if you skip
 the exercises. More on the exercises follows later in this chapter

--- a/chapters/01 introduction/01 how to use this book/description/description.nl.md
+++ b/chapters/01 introduction/01 how to use this book/description/description.nl.md
@@ -41,10 +41,12 @@ bestuderen wat je wilt, hoewel ik aanbeveel dat je ze op zijn minst
 doorbladert om te zien waar ze over gaan. Toekomstige edities van dit
 boek kunnen extra optioneel materiaal bevatten.
 
-Tijdens het bestuderen van dit boek moet je een computer bij de hand
-houden waarop je Python hebt geïnstalleerd (hoofdstuk
+Tijdens het bestuderen van dit boek heb je alles al op Dodona: je
+schrijft je code in de browser, voert ze daar uit en dient ze in, zonder
+dat je iets moet installeren (hoofdstuk
 3
-legt uit hoe je Python kunt krijgen voor jouw computer). Het boek bevat
+legt uit hoe je Python ook op je eigen computer kunt krijgen, als je
+daarnaast buiten de cursus wilt werken). Het boek bevat
 vele kleine en grotere oefeningen, die je allemaal moet doen tijdens het
 bestuderen. Als je veel van de oefeningen overslaat, zul je zeker niet
 leren programmeren. Meer over het doen van oefeningen volgt later in dit
@@ -55,9 +57,10 @@ Veel van de code fragmenten in dit boek – in ieder geval alle antwoorden
 op de opgaves en alle iets langere fragmenten – hebben een bestandsnaam
 boven de code genoemd. Dat betekent dat die code beschikbaar is als
 bestand, verkrijgbaar via de website die met dit boek geassocieerd is
-(<http://www.spronck.net/pythonbook>{:target="_blank"}). Je kunt de code downloaden en
-meteen in een editor laden als je dat wilt.
+(<http://www.spronck.net/pythonbook>{:target="_blank"}). Als je op je eigen computer
+werkt, kun je de code downloaden en meteen in een editor laden als je
+dat wilt.
 
 {:class="callout callout-info"}
 > #### Opmerking
-> **Het kopiëren en plakken van code vanuit een PDF bestand naar een editor werkt over het algemeen niet.** Tekst in een PDF bestand is niet opgeslagen op een manier die ervoor zorgt dat spaties correct gekopieerd worden. Dus je moet ofwel code handmatig intypen, ofwel de bestanden gebruiken die ik beschikbaar heb gesteld.
+> **Als je dit boek als PDF leest: het kopiëren en plakken van code vanuit een PDF bestand naar een editor werkt over het algemeen niet.** Tekst in een PDF bestand is niet opgeslagen op een manier die ervoor zorgt dat spaties correct gekopieerd worden. Dus je moet ofwel code handmatig intypen, ofwel de bestanden gebruiken die ik beschikbaar heb gesteld. Voor de code op Dodona geldt dit niet, die kun je gewoon kopiëren.

--- a/chapters/01 introduction/01 how to use this book/description/description.nl.md
+++ b/chapters/01 introduction/01 how to use this book/description/description.nl.md
@@ -43,10 +43,9 @@ boek kunnen extra optioneel materiaal bevatten.
 
 Tijdens het bestuderen van dit boek heb je alles al op Dodona: je
 schrijft je code in de browser, voert ze daar uit en dient ze in, zonder
-dat je iets moet installeren (hoofdstuk
-3
-legt uit hoe je Python ook op je eigen computer kunt krijgen, als je
-daarnaast buiten de cursus wilt werken). Het boek bevat
+dat je iets moet installeren (het volgende hoofdstuk legt uit hoe je
+Python ook op je eigen computer kunt krijgen, als je daarnaast buiten de
+cursus wilt werken). Het boek bevat
 vele kleine en grotere oefeningen, die je allemaal moet doen tijdens het
 bestuderen. Als je veel van de oefeningen overslaat, zul je zeker niet
 leren programmeren. Meer over het doen van oefeningen volgt later in dit

--- a/chapters/02 using python/00 introduction/description/description.en.md
+++ b/chapters/02 using python/00 introduction/description/description.en.md
@@ -1,5 +1,7 @@
 As explained in the introduction, you will need to write and run Python
-code to learn anything from this book. That means that you need a
-computer on which Python is installed, and you need to know how to write
-and run Python programs. This chapter will explain to you how to get "up
-and running" with Python.
+code to learn anything from this book. On Dodona that is already taken
+care of: you write your code in the browser, run it there, and hand it
+in, without installing anything. This chapter explains how to get "up
+and running" with Python on your own computer as well. That is worth
+doing if you want to experiment outside the course, but you do not need
+it for anything here.

--- a/chapters/02 using python/00 introduction/description/description.nl.md
+++ b/chapters/02 using python/00 introduction/description/description.nl.md
@@ -1,5 +1,7 @@
 Zoals ik heb uitgelegd in de introductie, zul je Python code moeten
-schrijven om te kunnen leren met dit boek. Dat betekent dat je een
-computer nodig hebt waarop Python geïnstalleerd is, en je moet weten hoe
-je Python programma's kunt schrijven. Dit hoofdstuk legt uit hoe je
-Python aan het werk krijgt.
+schrijven om te kunnen leren met dit boek. Op Dodona is dat al geregeld:
+je schrijft je code in de browser, voert ze daar uit en dient ze in,
+zonder dat je iets moet installeren. Dit hoofdstuk legt uit hoe je
+Python ook op je eigen computer aan het werk krijgt. Dat is de moeite
+waard als je buiten de cursus wilt experimenteren, maar je hebt het
+nergens voor nodig.

--- a/chapters/02 using python/01 installing/description/description.en.md
+++ b/chapters/02 using python/01 installing/description/description.en.md
@@ -1,3 +1,7 @@
+{:class="callout callout-info"}
+> #### Note
+> You do not need any of this to follow the course: on Dodona you write and run all your code in the browser. This page is here for readers who would also like to run Python on their own computer.
+
 To run Python programs, you need a "Python interpreter." Fortunately,
 Python interpreters are freely available for almost every machine in
 existence. Visit <http://www.python.org>{:target="_blank"} to download a Python
@@ -12,17 +16,3 @@ and copy it to another, which may have a different operating system, and
 it will probably still run as intended (unless the program has some
 system-specific content, but I will get to that in a much later
 chapter).
-
-Some Python courses use an online system in which students write Python
-code. That is a possible approach, but it has three disadvantages:
-
-1. there are free systems which are very limited and therefore less useful;
-
-2. there are paid systems which cost money and also have you deal with
-some peculiarities (as they run in a browser);
- 
-3. at some point you will have to run Python on your own computer anyway, so why not start with it? 
-
-That said, if you prefer to start with an online system and
-only move towards a locally installed version of Python in a later
-chapter, that is certainly possible.

--- a/chapters/02 using python/01 installing/description/description.nl.md
+++ b/chapters/02 using python/01 installing/description/description.nl.md
@@ -1,3 +1,7 @@
+{:class="callout callout-info"}
+> #### Opmerking
+> Je hebt niets van dit alles nodig om de cursus te volgen: op Dodona schrijf je al je code in de browser en voer je ze daar ook uit. Deze pagina is er voor wie Python ook op de eigen computer wil draaien.
+
 Om Python te gebruiken heb je een "Python interpreter" nodig. Python
 interpreters zijn gratis verkrijgbaar voor vrijwel alle computers. Via
 de website <http://www.python.org>{:target="_blank"} kun je een Python interpreter
@@ -13,17 +17,3 @@ machine geschreven hebt en dat kopiëren naar een andere machine met een
 ander besturingssysteem, en waarschijnlijk zal het programma nog steeds
 werken (tenzij het programma systeem-specifieke code bevat, maar dat
 bespreek ik in een veel later hoofdstuk).
-
-Er zijn Python cursussen die je gebruik laten maken van een online
-Python systeem, omdat ze weten dat het voor sommige mensen een obstakel
-is om software te installeren. Dat kan, maar het heeft drie nadelen:
-
-1. er zijn gratis systemen die heel beperkt en dus nauwelijks bruikbaar zijn;
-
-2. er zijn betaalde systemen die meer kunnen maar die geld kosten en vaak eigenaardigheden bevatten omdat ze nu eenmaal in een browser draaien;
- 
-3. uiteindelijk moet je er toch toe overgaan om Python op je eigen computer te installeren, dus waarom zou je er niet meteen mee beginnen?
-
-Maar als je die nadelen voor lief wilt nemen, zou je kunnen
-beginnen met een online Python systeem, en pas in een later hoofdstuk
-overgaan op een lokaal geïnstalleerd systeem.

--- a/chapters/02 using python/02 creating programs/description/description.en.md
+++ b/chapters/02 using python/02 creating programs/description/description.en.md
@@ -1,3 +1,7 @@
+{:class="callout callout-info"}
+> #### Note
+> You do not need any of this to follow the course: on Dodona you write and run all your code in the browser. This page is here for readers who would also like to run Python on their own computer.
+
 Python programs are created in the form of files. By convention, the
 name of the file that contains a Python program has the extension `.py`.
 

--- a/chapters/02 using python/02 creating programs/description/description.nl.md
+++ b/chapters/02 using python/02 creating programs/description/description.nl.md
@@ -1,3 +1,7 @@
+{:class="callout callout-info"}
+> #### Opmerking
+> Je hebt niets van dit alles nodig om de cursus te volgen: op Dodona schrijf je al je code in de browser en voer je ze daar ook uit. Deze pagina is er voor wie Python ook op de eigen computer wil draaien.
+
 Python programma's zijn bestanden. Over het algemeen wordt voor Python
 bestanden de extensie `.py` gebruikt.
 

--- a/chapters/02 using python/03 running programs/description/description.en.md
+++ b/chapters/02 using python/03 running programs/description/description.en.md
@@ -1,3 +1,7 @@
+{:class="callout callout-info"}
+> #### Note
+> You do not need any of this to follow the course: on Dodona you write and run all your code in the browser. This page is here for readers who would also like to run Python on their own computer.
+
 Once you have created a Python program, you see the program name
 displayed in the folder where you saved it. You can try to run it in the
 same way that you run other programs (e.g., by double-clicking on it).

--- a/chapters/02 using python/03 running programs/description/description.nl.md
+++ b/chapters/02 using python/03 running programs/description/description.nl.md
@@ -1,3 +1,7 @@
+{:class="callout callout-info"}
+> #### Opmerking
+> Je hebt niets van dit alles nodig om de cursus te volgen: op Dodona schrijf je al je code in de browser en voer je ze daar ook uit. Deze pagina is er voor wie Python ook op de eigen computer wil draaien.
+
 Wanneer je een Python programma geschreven hebt, zie je de naam van het
 programma in de folder waar je het hebt opgeslagen. Je kunt proberen het
 uit te voeren op dezelfde manier waarop je andere programma's start,

--- a/chapters/02 using python/04 reference material/description/description.en.md
+++ b/chapters/02 using python/04 reference material/description/description.en.md
@@ -8,9 +8,9 @@ is great by the time you have to use Python for practical problems, it
 does not help you to learn. So my advice is that you avoid such links
 while trying to learn programming.
 
-When you install Python, there usually is a manual installed in a Doc
-folder under the Python folder. You can use it if, for some reason, you
-are not connected to the Internet.
+If you install Python on your own computer, there usually is a manual
+installed in a Doc folder under the Python folder. You can use it if,
+for some reason, you are not connected to the Internet.
 
 If you are interested in another book besides this one, I recommend the
 classic *Think Python: How to Think Like a Computer Scientist*, by Allen

--- a/chapters/02 using python/04 reference material/description/description.nl.md
+++ b/chapters/02 using python/04 reference material/description/description.nl.md
@@ -8,9 +8,9 @@ zulke sites heel prettig zijn als je Python problemen probeert op te
 lossen in de praktijk, leer je er weinig van. Dus ik raad je aan dit
 soort sites te vermijden zolang je aan het leren bent.
 
-Wanneer je Python installeert, wordt er meestal ook een handboek
-geïnstalleerd in een `Doc` folder onder de Python folder. Die kun je
-gebruiken als je niet met Internet verbonden bent.
+Als je Python op je eigen computer installeert, wordt er meestal ook een
+handboek geïnstalleerd in een `Doc` folder onder de Python folder. Die
+kun je gebruiken als je niet met Internet verbonden bent.
 
 Als je nog een boek wilt gebruiken naast dit boek, en je hebt geen
 problemen met Engels, dan beveel ik het klassieke boek *Think Python:

--- a/chapters/02 using python/05 exercises/01 hello world/description/description.en.md
+++ b/chapters/02 using python/05 exercises/01 hello world/description/description.en.md
@@ -9,3 +9,7 @@ The code is already waiting for you in the editor below, so you can hand
 it in as it is. Press **Submit** and observe how Dodona runs your program
 and shows you that the text "Hello, world!" is exactly what was
 expected.
+
+{:class="callout callout-info"}
+> #### Note
+> Do you want to run this on your own computer as well? Install Python, start IDLE, and create a file `hello.py` in which you place the line of code above. Run the program, and observe how the text "Hello, world!" is displayed in the IDLE shell.

--- a/chapters/02 using python/05 exercises/01 hello world/description/description.en.md
+++ b/chapters/02 using python/05 exercises/01 hello world/description/description.en.md
@@ -1,12 +1,12 @@
-Download Python and install it on the
-machine of your choice. Run IDLE. Create a file `hello.py`, in which you
-place the code of the *Hello World* program shown in Chapter
-2
-– it consists of one line of code, namely:
+Write the *Hello World* program shown in Chapter
+2.
+It consists of one line of code, namely:
 
 ```python
 print( "Hello, world!" )
 ```
 
-Run the program, and observe how the text "Hello, world!" is displayed
-in the IDLE shell.
+The code is already waiting for you in the editor below, so you can hand
+it in as it is. Press **Submit** and observe how Dodona runs your program
+and shows you that the text "Hello, world!" is exactly what was
+expected.

--- a/chapters/02 using python/05 exercises/01 hello world/description/description.en.md
+++ b/chapters/02 using python/05 exercises/01 hello world/description/description.en.md
@@ -1,6 +1,5 @@
-Write the *Hello World* program shown in Chapter
-2.
-It consists of one line of code, namely:
+Write the *Hello World* program shown in the introduction. It consists
+of one line of code, namely:
 
 ```python
 print( "Hello, world!" )

--- a/chapters/02 using python/05 exercises/01 hello world/description/description.nl.md
+++ b/chapters/02 using python/05 exercises/01 hello world/description/description.nl.md
@@ -1,12 +1,12 @@
-Download Python and installeer het op je
-computer. Start IDLE. Creëer een bestand `hello.py`, waarin je de code
-schrijft van het *Hello World* programma dat ik liet zien in hoofdstuk
-2
-– het bestaat uit één regel code, namelijk:
+Schrijf het *Hello World* programma dat ik liet zien in hoofdstuk
+2.
+Het bestaat uit één regel code, namelijk:
 
 ```python
 print( "Hello, world!" )
 ```
 
-Draai het programma, en zie dat de tekst "Hello, world!" getoond wordt
-in de IDLE shell.  
+De code staat al klaar in de editor hieronder, dus je kunt ze indienen
+zoals ze is. Klik op **Indienen** en zie hoe Dodona je programma
+uitvoert en je toont dat de tekst "Hello, world!" precies is wat er
+verwacht werd.

--- a/chapters/02 using python/05 exercises/01 hello world/description/description.nl.md
+++ b/chapters/02 using python/05 exercises/01 hello world/description/description.nl.md
@@ -9,3 +9,7 @@ De code staat al klaar in de editor hieronder, dus je kunt ze indienen
 zoals ze is. Klik op **Indienen** en zie hoe Dodona je programma
 uitvoert en je toont dat de tekst "Hello, world!" precies is wat er
 verwacht werd.
+
+{:class="callout callout-info"}
+> #### Opmerking
+> Wil je dit ook op je eigen computer draaien? Installeer Python, start IDLE, en creëer een bestand `hello.py` waarin je de regel code hierboven zet. Draai het programma, en zie dat de tekst "Hello, world!" getoond wordt in de IDLE shell.

--- a/chapters/02 using python/05 exercises/01 hello world/description/description.nl.md
+++ b/chapters/02 using python/05 exercises/01 hello world/description/description.nl.md
@@ -1,5 +1,4 @@
-Schrijf het *Hello World* programma dat ik liet zien in hoofdstuk
-2.
+Schrijf het *Hello World* programma dat ik liet zien in de inleiding.
 Het bestaat uit één regel code, namelijk:
 
 ```python

--- a/chapters/02 using python/05 exercises/02 evaluate an expression/description/description.en.md
+++ b/chapters/02 using python/05 exercises/02 evaluate an expression/description/description.en.md
@@ -1,21 +1,28 @@
-In the IDLE shell you can type commands on the
-IDLE prompt (`>>>`). Give the command `print(7/4)`. You will see that it
-prints the answer $$1.75$$. Then give the command $$7/4$$ (i.e., without
+In an interactive Python session you can type commands on the prompt
+(`>>>`). On Dodona you get such a session by pressing **To sandbox**
+underneath the editor. Give the command `print(7/4)`. You will see that
+it prints the answer $$1.75$$. Then give the command $$7/4$$ (i.e., without
 `print`). Observe that it also prints the answer $$1.75$$.
 
-The reason is that the IDLE shell will always display the result of a
-command. The result of $$7/4$$ is $$1.75$$, and therefore it displays
-$$1.75$$. The result of a `print` command is nothing, so the shell
+```console?lang=python&prompt=>>>
+>>> print(7/4)
+1.75
+>>> 7/4
+1.75
+```
+
+The reason is that an interactive session will always display the result
+of a command. The result of $$7/4$$ is $$1.75$$, and therefore it displays
+$$1.75$$. The result of a `print` command is nothing, so the session
 displays nothing – however, the `print` command causes the display of
 whatever is within the parentheses, which is the value resulting from
 dividing $$7$$ by $$4$$, which is $$1.75$$. Therefore, in both cases you see
 $$1.75$$, but one is the result of the use of the `print` command, while
-the other is the result of the shell showing you the evaluation of a
+the other is the result of the session showing you the evaluation of a
 calculation.
 
-Now write a Python program that contains only the command $$7/4$$. Before
-you run it, think about what you expect to happen when you run it. Will
-the shell display $$1.75$$? Will it display nothing? Or will you see an
-error?
+Now write a Python program that contains only the command $$7/4$$, and
+hand it in. Before you do, think about what you expect to happen. Will
+it display $$1.75$$? Will it display nothing? Or will you see an error?
 
-Check if your expectation is correct.  
+Check if your expectation is correct.

--- a/chapters/02 using python/05 exercises/02 evaluate an expression/description/description.en.md
+++ b/chapters/02 using python/05 exercises/02 evaluate an expression/description/description.en.md
@@ -1,6 +1,7 @@
 In an interactive Python session you can type commands on the prompt
 (`>>>`). On Dodona you get such a session by pressing **To sandbox**
-underneath the editor. Give the command `print(7/4)`. You will see that
+underneath the editor; on your own computer you get one by starting
+IDLE. Give the command `print(7/4)`. You will see that
 it prints the answer $$1.75$$. Then give the command $$7/4$$ (i.e., without
 `print`). Observe that it also prints the answer $$1.75$$.
 

--- a/chapters/02 using python/05 exercises/02 evaluate an expression/description/description.nl.md
+++ b/chapters/02 using python/05 exercises/02 evaluate an expression/description/description.nl.md
@@ -1,6 +1,7 @@
 In een interactieve Python sessie kun je commando's typen op de prompt
 (`>>>`). Op Dodona krijg je zo'n sessie door onder de editor op **Naar
-sandbox** te klikken. Geef het commando `print(7/4)`. Je ziet dat de
+sandbox** te klikken; op je eigen computer krijg je er een door IDLE te
+starten. Geef het commando `print(7/4)`. Je ziet dat de
 uitkomst $$1.75$$ is. Geef daarna het commando $$7/4$$ (dus zonder `print`).
 Zie nu dat het antwoord ook $$1.75$$ is.
 

--- a/chapters/02 using python/05 exercises/02 evaluate an expression/description/description.nl.md
+++ b/chapters/02 using python/05 exercises/02 evaluate an expression/description/description.nl.md
@@ -1,23 +1,30 @@
-In de IDLE shell kun je commando's typen op de
-"IDLE prompt" (`>>>`). Geef het commando `print(7/4)`. Je ziet dat de
+In een interactieve Python sessie kun je commando's typen op de prompt
+(`>>>`). Op Dodona krijg je zo'n sessie door onder de editor op **Naar
+sandbox** te klikken. Geef het commando `print(7/4)`. Je ziet dat de
 uitkomst $$1.75$$ is. Geef daarna het commando $$7/4$$ (dus zonder `print`).
 Zie nu dat het antwoord ook $$1.75$$ is.
 
-De reden dat je in het tweede geval ook het antwoord ziet, is dat de
-IDLE shell altijd de uitkomst van een commando laat zien. De uitkomst
-van $$7/4$$ is $$1.75$$, en dus laat IDLE $$1.75$$ zien. De uitkomst van een
-`print` commando is niks, dus de shell laat niks zien – echter, het
-`print` commando zelf drukt de uitkomst af van wat er zich tussen de
-haakjes bevindt, en dat is het resultaat van wat je krijgt als je $$7$$
-deelt door $$4$$, dus $$1.75$$. Daarom zie je in beide gevallen $$1.75$$, maar
-de eerste is het resultaat van het gebruik van het `print` commando,
-terwijl het tweede het resultaat is van de shell die laat zien wat de
-evaluatie van een berekening is.
+```console?lang=python&prompt=>>>
+>>> print(7/4)
+1.75
+>>> 7/4
+1.75
+```
 
-Schrijf nu een Python programma (dus in een bestand met de extensie
-`.py`) dat alleen het commando $$7/4$$ bevat. Voordat je dit programma
-uitvoert, bedenk wat je verwacht dat er gebeurt als je het uitvoert. Zal
-de shell $$1.75$$ laten zien? Of laat de shell niks zien? Of krijg je een
+De reden dat je in het tweede geval ook het antwoord ziet, is dat een
+interactieve sessie altijd de uitkomst van een commando laat zien. De
+uitkomst van $$7/4$$ is $$1.75$$, en dus laat de sessie $$1.75$$ zien. De
+uitkomst van een `print` commando is niks, dus de sessie laat niks zien
+– echter, het `print` commando zelf drukt de uitkomst af van wat er zich
+tussen de haakjes bevindt, en dat is het resultaat van wat je krijgt als
+je $$7$$ deelt door $$4$$, dus $$1.75$$. Daarom zie je in beide gevallen
+$$1.75$$, maar de eerste is het resultaat van het gebruik van het `print`
+commando, terwijl het tweede het resultaat is van de sessie die laat
+zien wat de evaluatie van een berekening is.
+
+Schrijf nu een Python programma dat alleen het commando $$7/4$$ bevat, en
+dien het in. Bedenk voordat je dat doet wat je verwacht dat er gebeurt.
+Zal $$1.75$$ getoond worden? Of wordt er niks getoond? Of krijg je een
 foutmelding?
 
 Controleer of je verwachting uitkomt.

--- a/chapters/15 operating system/02 command prompt/description/description.en.md
+++ b/chapters/15 operating system/02 command prompt/description/description.en.md
@@ -42,7 +42,8 @@ working directory," "make a new directory," "remove an empty directory,"
 it depends on the operating system what exactly the commands are that
 you need to give to achieve these things.
 
-On your system, find the command shell and run the program. On Windows,
-type "dir" to see the files in the current directory. On Macs and Linux,
-this command is usually "ls." After doing this, you can close the
-command shell again.
+If you have your own computer at hand, it is worth finding the command
+shell and running it once. On Windows, type "dir" to see the files in
+the current directory. On Macs and Linux, this command is usually "ls."
+After doing this, you can close the command shell again. You do not need
+any of this for the exercises in this course, which Dodona runs for you.

--- a/chapters/15 operating system/02 command prompt/description/description.nl.md
+++ b/chapters/15 operating system/02 command prompt/description/description.nl.md
@@ -44,7 +44,9 @@ bestand," etcetera. Wederom, het is afhankelijk van het
 besturingssysteem wat je geacht wordt te doen om deze zaken te
 bewerkstelligen.
 
-Zoek op je systeem op waar je de command shell kunt starten en voer het
-programma uit. Op Windows, typ "dir" om de bestanden in de huidige
-directory te zien. Op Mac en Linux doe je dit meestal met "ls." Nadat je
-dit geprobeerd hebt, kun je de command shell weer sluiten.
+Als je een eigen computer bij de hand hebt, is het de moeite waard om de
+command shell eens op te zoeken en te starten. Op Windows, typ "dir" om
+de bestanden in de huidige directory te zien. Op Mac en Linux doe je dit
+meestal met "ls." Nadat je dit geprobeerd hebt, kun je de command shell
+weer sluiten. Voor de oefeningen in deze cursus heb je dit allemaal niet
+nodig, die voert Dodona voor je uit.

--- a/chapters/24 command line processing/01 the command line/description/description.en.md
+++ b/chapters/24 command line processing/01 the command line/description/description.en.md
@@ -92,98 +92,10 @@ filename), you can, of course, use the `len()` function.
 
 When you work from an editor, in general you cannot supply command-line
 arguments to your Python programs. So if you want to experiment with
-this, you actually have to test your programs on the command line. That
-is a bit of a hassle, especially during development time. However, I can
-tell you how to set up your programs in such a way that handling command
-line arguments is optional.
-
-## Flexible command line processing
-
-When I code Python programs, I prefer working from an editor. There are
-a few editors that support supplying command line arguments to a program
-when testing it, but most do not. So I want to develop my programs in
-such a way that I can build them as if they process command line
-arguments, but that I can test them directly from an editor, and only
-need to test whether or not they actually process command line
-parameters correctly once. I do that as follows:
-
-For every parameter that can be controlled via the command line, I
-create a global variable. I fill these global variables with default
-values. In the rest of the program, I use these variables as if they are
-constants. Only at the very start of the main program I check for the
-existence of command line arguments, and if I find those, I overwrite
-the variables with values that are supplied on the command line.
-
-The advantage of this approach is that I can develop my program without
-using command line arguments. If I want to use different values for the
-command line arguments for testing, I simply use different values for
-the variables in which I will store the command line arguments. I can
-even set up the program in such a way that it will either fill a
-variable via a command line argument, or will ask the user for the value
-if it was not supplied on the command line.
-
-Typically, such code looks as follows:
-
-```python
-import sys
-
-# 3 variables for holding the command line parameters
-inputfile = "input.txt"
-outputfile = "output.txt"
-shift = 3
-
-# Processing the command line parameters
-# (works with 0, 1, 2, or 3 parameters)
-if len( sys.argv ) > 1:
-    inputfile = sys.argv[1]
-if len( sys.argv ) > 2:
-    outputfile = sys.argv[2]
-if len( sys.argv ) > 3:
-    try:
-        shift = int( sys.argv[3] )
-    except TypeError:
-        print( sys.argv[3], "is not an integer." )
-        sys.exit(1)
-```
-
-In this code, three command line arguments are supported: the first two
-are strings, and the third is an integer. The third one is immediately
-converted from a string (which a command line argument always is) to an
-integer, and the program is aborted if this conversion fails. I could
-have built in more checks for demonstration, but I assume that at this
-point in your programming career that does not pose any problems to you.
-
-All three arguments have a default value: the first string has default
-value `"input.txt"`, the second string has default value `"output.txt"`,
-and the integer has as default value 3. You are not expected to supply
-all three arguments on the command line: if you supply zero, all three
-default values will be used; if you supply one, the first string will be
-overwritten with the command line argument, while the other two
-variables will retain their default value; etcetera.
-
-### `sys.exit()`
-
-In the example code above the program is aborted using `sys.exit()` if
-an argument is not meeting the requirements set to it. `sys.exit()` was
-introduced in Chapter
-7.
-However, I did not explain at that time that `sys.exit()` can get a
-numerical argument, which you see above. The use of this argument is
-that it will be returned to the batch file that is running the program,
-and the batch file can respond to it if it was designed to. The
-numerical argument is supposed to be an error code. Typically, zero is
-given as argument if everything was processed correctly (a program that
-ends normally will also return zero), and otherwise another number is
-used. As some systems are limited to the values zero to 255 as program
-return values, it is convention to limit the `sys.exit()` argument to
-that range of values too.
-
-### `argparse`
-
-If you want module support for command line processing, Python supplies
-a standard module `argparse` for that. Frankly, I do not see much use
-for such a module, as command line processing is too simple to spend
-much time on. However, some Python programs, in particular those that
-are meant to enhance the system, support a large and complex variety of
-command line arguments, and may benefit from such a module. It is up to
-you to study it if you think it may help you.
+this on your own computer, you actually have to test your programs on
+the command line. That is a bit of a hassle, especially during
+development time. On Dodona you do not have to arrange any of that: the
+exercises of this chapter are run with the arguments they need, so you
+can write your program as if it was called from the command line.
+However, I can tell you how to set up your programs in such a way that
+handling command line arguments is optional.

--- a/chapters/24 command line processing/01 the command line/description/description.nl.md
+++ b/chapters/24 command line processing/01 the command line/description/description.nl.md
@@ -95,8 +95,12 @@ hoeveel command line argumenten er zijn, kun je, zoals gewoonlijk, de
 
 Als je programmeert in een editor die je ook gebruikt om je programma's
 te testen, kun je over het algemeen geen command-line argumenten
-specificeren. Dus als je hiermee wilt experimenteren, moet je je
-programma's daadwerkelijk testen in de command shell. Dat is een heel
-gedoe, zeker tijdens het ontwikkelen van een programma. Ik kan je echter
-vertellen hoe je je programma's zodanig kunt opzetten dat het afhandelen
-van command-line argumenten optioneel is.
+specificeren. Dus als je hier op je eigen computer mee wilt
+experimenteren, moet je je programma's daadwerkelijk testen in de
+command shell. Dat is een heel gedoe, zeker tijdens het ontwikkelen van
+een programma. Op Dodona hoef je dat allemaal niet te regelen: de
+oefeningen van dit hoofdstuk worden uitgevoerd met de argumenten die ze
+nodig hebben, dus je kunt je programma schrijven alsof het vanaf de
+command line wordt opgeroepen. Ik kan je echter vertellen hoe je je
+programma's zodanig kunt opzetten dat het afhandelen van command-line
+argumenten optioneel is.

--- a/chapters/28 appendices/01 troubleshooting/description/description.en.md
+++ b/chapters/28 appendices/01 troubleshooting/description/description.en.md
@@ -11,7 +11,9 @@ or
 32
 to solve the problem), or you placed them in a location that Python has
 no access to. In the last case, make sure you copy them to the same
-place as where you keep your Python programs.
+place as where you keep your Python programs. On Dodona neither module
+is available, so a solution that you submit should not import them: read
+the input with `input()` instead.
 
 ### I get a FileNotFoundError: [Errno 2]
 

--- a/chapters/28 appendices/01 troubleshooting/description/description.nl.md
+++ b/chapters/28 appendices/01 troubleshooting/description/description.nl.md
@@ -10,7 +10,9 @@ of
 32
 om dit op te lossen), of je hebt ze geplaatst op een locatie waar Python
 ze niet kan vinden. Zorg dat je ze kopieert naar dezelfde plaats als
-waar je je Python programma's zet.
+waar je je Python programma's zet. Op Dodona is geen van beide modules
+beschikbaar, dus een oplossing die je indient mag ze niet importeren:
+lees de input dan in met `input()`.
 
 ### Ik krijg een FileNotFoundError: [Errno 2]
 

--- a/chapters/28 appendices/04 pcmaze.py/description/description.en.md
+++ b/chapters/28 appendices/04 pcmaze.py/description/description.en.md
@@ -1,3 +1,7 @@
+{:class="callout callout-info"}
+> #### Note
+> This appendix documents the `pcmaze` module from the printed book, as reference material for readers who run the examples in their own environment, outside Dodona. The module is not available on Dodona, so you cannot import it in a solution that you submit. You only need it if you want to try the maze example on your own computer.
+
 In Chapter
 10
 an example of searching a maze is presented. In that example a module

--- a/chapters/28 appendices/04 pcmaze.py/description/description.nl.md
+++ b/chapters/28 appendices/04 pcmaze.py/description/description.nl.md
@@ -1,3 +1,7 @@
+{:class="callout callout-info"}
+> #### Opmerking
+> Deze appendix documenteert de `pcmaze` module uit het boek, als naslagwerk voor wie de voorbeelden in een eigen omgeving uitvoert, buiten Dodona. De module is niet beschikbaar op Dodona, dus je kunt hem niet importeren in een oplossing die je indient. Je hebt hem enkel nodig als je het doolhofvoorbeeld op je eigen computer wilt uitproberen.
+
 In hoofdstuk
 10
 laat ik in een voorbeeld een doolhof doorzoeken. In dat voorbeeld

--- a/chapters/28 appendices/05 test text files/description/description.en.md
+++ b/chapters/28 appendices/05 test text files/description/description.en.md
@@ -1,3 +1,7 @@
+{:class="callout callout-info"}
+> #### Note
+> This appendix lists the test files from the printed book, as reference material for readers who run the examples in their own environment, outside Dodona. These files are not available on Dodona: the exercises that work with files come with their own data files, which are already in the current directory when your solution runs. You only need to create these files if you want to try the examples on your own computer.
+
 In Chapter
 17
 several small text files are used to demonstrate functionalities.

--- a/chapters/28 appendices/05 test text files/description/description.nl.md
+++ b/chapters/28 appendices/05 test text files/description/description.nl.md
@@ -1,3 +1,7 @@
+{:class="callout callout-info"}
+> #### Opmerking
+> Deze appendix bevat de testbestanden uit het boek, als naslagwerk voor wie de voorbeelden in een eigen omgeving uitvoert, buiten Dodona. Deze bestanden zijn niet beschikbaar op Dodona: de oefeningen die met bestanden werken, komen met hun eigen databestanden, die al in de huidige directory staan wanneer je oplossing wordt uitgevoerd. Je hoeft deze bestanden enkel zelf te maken als je de voorbeelden op je eigen computer wilt uitproberen.
+
 In hoofdstuk
 17
 worden verscheidene korte tekstbestanden gebruikt om functionaliteiten

--- a/chapters/28 appendices/06 answers to exercises/description/description.en.md
+++ b/chapters/28 appendices/06 answers to exercises/description/description.en.md
@@ -104,7 +104,8 @@ above is harder, because you need nested conditions and an early escape.
 #### Answer 2.1
 
 You handed in your first program and got your first "Correct" back.
-Congratulations!
+Congratulations! And if you also tried it on your own computer, you now
+have Python running there as well.
 
 #### Answer 2.2
 

--- a/chapters/28 appendices/06 answers to exercises/description/description.en.md
+++ b/chapters/28 appendices/06 answers to exercises/description/description.en.md
@@ -103,18 +103,18 @@ above is harder, because you need nested conditions and an early escape.
 
 #### Answer 2.1
 
-You now have Python running on your computer. Congratulations!
+You handed in your first program and got your first "Correct" back.
+Congratulations!
 
 #### Answer 2.2
 
-You will see nothing in the shell (apart from a display of the word
-`RESTART` that you always see when running a program). $$7/4$$ is a legal
-Python statement, so the program will not give an error. The program
-just calculates $$7/4$$, but does not display the result using a print
-statement, so the program does not show $$1.75$$. The shell, however,
-displays the result of running the program. But since a program has no
-result by itself, there is nothing for the shell to display either. So
-you see nothing.
+The program produces no output at all. $$7/4$$ is a legal Python
+statement, so the program will not give an error. The program just
+calculates $$7/4$$, but does not display the result using a print
+statement, so the program does not show $$1.75$$. This is the difference
+with an interactive session: a session displays the result of every
+command you type, but a program that is run only shows what it prints
+itself. So you see nothing.
 
 ### Chapter 4
 

--- a/chapters/28 appendices/06 answers to exercises/description/description.nl.md
+++ b/chapters/28 appendices/06 answers to exercises/description/description.nl.md
@@ -117,7 +117,8 @@ een stuk lastiger, omdat je er geneste condities voor nodig hebt.
 #### Antwoord 2.1
 
 Je hebt je eerste programma ingediend en je eerste "Correct" gekregen.
-Gefeliciteerd!
+Gefeliciteerd! En als je het ook op je eigen computer hebt geprobeerd,
+draait Python daar nu ook.
 
 #### Antwoord 2.2
 

--- a/chapters/28 appendices/06 answers to exercises/description/description.nl.md
+++ b/chapters/28 appendices/06 answers to exercises/description/description.nl.md
@@ -116,17 +116,17 @@ een stuk lastiger, omdat je er geneste condities voor nodig hebt.
 
 #### Antwoord 2.1
 
-Python draait nu op je computer. Gefeliciteerd!
+Je hebt je eerste programma ingediend en je eerste "Correct" gekregen.
+Gefeliciteerd!
 
 #### Antwoord 2.2
 
-Je ziet niets in de shell (behalve het woord `RESTART` dat je altijd
-ziet als je een programma draait). $$7/4$$ is een correct Python commando,
-dus het programma geeft geen foutmelding. Het programma rekent $$7/4$$
-uit, maar toont geen resultaat, dus het programma laat niet $$1.75$$ zien.
-De shell toont het resultaat van het draaien van het programma. Maar
-omdat het programma zelf geen resultaat heeft, is er ook niks dat de
-shell kan laten zien. Dus je ziet niets.
+Het programma toont helemaal niets. $$7/4$$ is een correct Python
+commando, dus het programma geeft geen foutmelding. Het programma rekent
+$$7/4$$ uit, maar toont geen resultaat, dus het programma laat niet
+$$1.75$$ zien. Dat is het verschil met een interactieve sessie: een sessie
+toont de uitkomst van elk commando dat je typt, maar een programma dat
+wordt uitgevoerd toont enkel wat het zelf afdrukt. Dus je ziet niets.
 
 ### Hoofdstuk 4
 


### PR DESCRIPTION
**TODO (author) — drafted by Claude: proofread, verify and remove this line.**

The book was written for someone sitting at their own machine, so it opens by telling students to install Python before they can do anything. On Dodona that is simply wrong: you write, run and hand in all your code in the browser. Chapter 2 even argued *against* online systems ("at some point you will have to run Python on your own computer anyway, so why not start with it?"), which contradicts the platform the course runs on.

The local Python material is worth keeping for readers who want to experiment outside the course, so **none of the local how-to is deleted**. What changes is the framing: Dodona is the default, running Python on your own machine is the optional extra, and where the two differ both are given.

## What changed

| Where | Change |
|---|---|
| ch. 1, how to use this book | "you should have a computer with Python installed at hand" now says everything is already on Dodona; the download-into-your-editor line and the PDF copy-paste callout are scoped to working locally |
| ch. 2, introduction | rewritten to introduce the optional local track |
| ch. 2, getting Python | drops the three-point argument against online systems, keeps the install instructions |
| ch. 2, creating / running programs | content untouched, prefixed with a callout |
| ch. 2, reference material | the `Doc` folder is now conditional on installing locally |
| ch. 2, Hello, world! | the assignment is now handing in the boilerplate that was already in the editor, with the book's install-and-run-in-IDLE instructions kept underneath as an optional note |
| ch. 2, evaluate an expression | reframed onto the sandbox, naming IDLE alongside it as the other way to get an interactive session |
| ch. 15, command prompt | the closing "find the command shell on your system and run it" is an invitation, not an instruction; the `dir`/`ls` steps stay |
| ch. 24, the command line | "you actually have to test your programs on the command line" was wrong here, since Dodona runs this chapter's exercise with its arguments |
| ch. 28, pcmaze.py + test text files | the same callout `pcinput.py` already got |
| ch. 28, troubleshooting | the ImportError entry told you to copy `pcinput`/`pcmaze` next to your code, which cannot work on Dodona |
| ch. 28, answers | the two chapter 2 answers were about IDLE, one explaining the `RESTART` line of the IDLE shell |

The callout reuses the existing house pattern (the `callout callout-info` "Note" / "Opmerking" block from the pcinput work), so nothing new is introduced.

## Deliberately left alone

**Chapter 15's file system page.** It explains paths, the current directory, `.` and `..`, which is just as true on Dodona, and it never tells you to install or run anything. Rewriting it would have been churn.

**Chapter 24's flexible command line processing.** Its opening is the author explaining why he prefers defaults over required arguments. That rationale still stands.

## Chapter numbering

The book's numeric cross-references are one higher than the series numbers students see on Dodona: the book's "Chapter 3" is the series shown as "2. Using Python". That holds throughout, **399 standalone numeric references across 181 files**, so it is not something to correct one reference at a time. For the two sentences rewritten here the number is simply dropped ("the next chapter", "the introduction"), which reads correctly under either numbering. The systemic mismatch is left for a separate decision.

## Also fixed here

The English *the command line* carried a verbatim copy of the whole next activity, *flexible command line processing*, which is why it was 189 lines against 102 for the Dutch. Verified the duplicated block was byte-identical to the other activity before dropping it.

## Testing

The two chapter 2 exercises are really submitted, so they were run against the real judge in Docker:

<details>
<summary>Judge output</summary>

```
$ scripts/verify_pythia_exercise.py "…/01 hello world" "…/solution/solution.en.py"
1 passed, 0 failed
submission status: correct answer (accepted: True)
OK: all tests passed

$ scripts/verify_pythia_exercise.py "…/02 evaluate an expression" "…/solution/solution.en.py"
1 passed, 0 failed
submission status: correct answer (accepted: True)
OK: all tests passed
```

And the counter-check, which is the interesting one: the rewritten description claims a bare `7/4` prints nothing when run as a program. Handing in `print(7/4)` must therefore be rejected.

```
$ scripts/verify_pythia_exercise.py "…/02 evaluate an expression" wrong_expr.py --expect-fail
    FAIL  testcase: testcase 1   [wrong answer]
            expected:
            generated: 1.75
OK: the solution was rejected, as expected
```

</details>

Mechanical checks: 294 EN and 294 NL descriptions, no activity left with only one language, all 294 `config.json` still valid, and a grep for the old instructions ("you need a computer", "Download Python", "Run IDLE", "in the IDLE shell") comes back with only the intended hits, all inside optional pages or callouts. The full list of removed lines was reviewed one by one to check nothing usable was dropped rather than reworded.

To check on Dodona: open chapter 1 "How to use this book" and the whole of chapter 2 in both `nl` and `en`, and confirm the callouts render as info blocks.

## Follow-ups, not in this PR

- The medium and light tiers of the same problem, roughly 30 more activities: the pcinput/pcmaze download notes in ch. 5 and 9, the editor tab-settings paragraph in ch. 6, the `pc_rose.txt` availability notes in ch. 16, 17, 18 and 26, the Python-shell framing in ch. 3, the `bs4`/`pip` install notes in ch. 26.
- The chapter-numbering mismatch described above.
- `chapters/16 text files/08 exercises/03 vowel removal/description.en.md` has untranslated Dutch on line 5.
- Each chapter's `00 introduction` is duplicated verbatim as the series description on Dodona, so the chapter 2 one needs the same rewrite applied there by hand. This looks systemic across all 28 chapters and probably deserves its own think.
